### PR TITLE
Windows w/ Intel 18.0.5 workarounds

### DIFF
--- a/src/FD/geometry/geometry_interface.f90
+++ b/src/FD/geometry/geometry_interface.f90
@@ -19,8 +19,8 @@ module geometry_interface
     private
   contains
     procedure build
-    procedure(set_json_file), deferred ::  set_grid_specification
-    procedure(set_metadata), deferred ::  set_block_metadata
+    procedure(set_json_file), deferred :: set_grid_specification
+    procedure(set_metadata), deferred :: set_block_metadata
   end type
 
 
@@ -36,18 +36,19 @@ module geometry_interface
 
   end interface
 
+  abstract interface
 
-  interface
-
-    module subroutine set_json_file(this, grid_description_file)
+    subroutine set_json_file(this, grid_description_file)
       !! define json_file problem description
+      import geometry
       implicit none
       class(geometry), intent(out) :: this
       character(len=*), intent(in) :: grid_description_file
     end subroutine
 
-    module subroutine set_metadata(this)
+    subroutine set_metadata(this)
       !! read grid metadata from json_file stored in child class
+      import geometry
       implicit none
       class(geometry), intent(inout) :: this
     end subroutine

--- a/src/FD/geometry/geometry_interface.f90
+++ b/src/FD/geometry/geometry_interface.f90
@@ -19,8 +19,8 @@ module geometry_interface
     private
   contains
     procedure build
-    procedure(set_json_file), deferred, private ::  set_grid_specification
-    procedure(set_metadata), deferred, private ::  set_block_metadata
+    procedure(set_json_file), deferred ::  set_grid_specification
+    procedure(set_metadata), deferred ::  set_block_metadata
   end type
 
 
@@ -37,7 +37,7 @@ module geometry_interface
   end interface
 
 
-  abstract interface
+  interface
 
     module subroutine set_json_file(this, grid_description_file)
       !! define json_file problem description

--- a/src/FD/geometry/plate_3D_interface.F90
+++ b/src/FD/geometry/plate_3D_interface.F90
@@ -17,7 +17,6 @@ module plate_3D_interface
   private
   public :: plate_3D
 
-
   type, extends(geometry) :: plate_3D
     !! encapsulate the grid specification for a plate_3D object
     private

--- a/src/FD/grid/problem_discretization_interface.F90
+++ b/src/FD/grid/problem_discretization_interface.F90
@@ -8,6 +8,7 @@ module problem_discretization_interface
   use object_interface, only : object
   use structured_grid_interface, only : structured_grid
   use geometry_interface, only : geometry
+  use plate_3D_interface, only : plate_3D
   implicit none
 
   private
@@ -52,7 +53,6 @@ module problem_discretization_interface
 
     module subroutine minimally_resolved_plate_3D(this,plate_3D_geometry)
       !! Define a grid with points only at the corners of each structured-grid block subdomain
-      use plate_3D_interface, only : plate_3D
       implicit none
       class(problem_discretization), intent(inout) :: this
       type(plate_3D), intent(in) :: plate_3D_geometry

--- a/src/FD/tests/unit/test-adi-time-advancing.f90
+++ b/src/FD/tests/unit/test-adi-time-advancing.f90
@@ -51,6 +51,7 @@ program main
     real(rkind)  :: dx_m, dy_m, dz_m
     real(rkind)  :: dx_f, dy_f, dz_f
     real(rkind)  :: dx_b, dy_b, dz_b
+    integer(ikind), dimension(3) :: n
     real(rkind), dimension(:), allocatable :: a,b,c,d
     real(rkind)                            :: f,dt,t
 
@@ -58,7 +59,8 @@ program main
     dt=0.002
     t=0.0
     do while(t<=0.1)
-    associate(n=>shape(global_grid_block))
+    !associate(n=>shape(global_grid_block))
+    n = shape(global_grid_block)
       !x direction
       allocate(a(n(1)-1),b(n(1)-1),c(n(1)-1),d(n(1)-1))
       call get_ddy2(global_grid_block)
@@ -163,7 +165,7 @@ program main
         end do
       end do
       deallocate(a,b,c,d)
-    end associate
+    !end associate
     t=t+dt
     end do
   end block time_advancing
@@ -226,15 +228,16 @@ contains
     real(rkind), parameter :: dx=0.6/(15.0), dy=0.6/(15.0)
     real(rkind), parameter :: dx_s=0.4/5.0, dy_s=0.4/5.0
     real(rkind), dimension(:,:,:,:) ,allocatable  :: vector_field
+    integer(ikind) :: ii, jj, kk
 
     allocate( vector_field(nx,ny,nz,components) )
 
     associate( dz=>2.0/(nz-1) )
-      do concurrent( i=1:nx, j=1:ny, k=1:nz )
-        vector_field(i,j,k,1) = merge(-0.6+(i-6)*dx, merge( -1.0+(i-1)*dx_s, 0.6+(i-36)*dx_s, i<6), i>=6 .and. i<=36)
-        vector_field(i,j,k,2) = merge(-0.6+(j-6)*dy, merge( -1.0+(j-1)*dy_s, 0.6+(j-36)*dy_s, j<6), j>=6 .and. j<=36)
-        vector_field(i,j,k,3) = -1.0+(k-1)*dz
-        vector_field(i,j,k,4) = merge(2.0, 1.0, (i==1 .or. i==nx .or. j==1 .or. j==ny .or. k==1 .or. k==nz))
+      do concurrent( ii=1:nx, jj=1:ny, kk=1:nz )
+        vector_field(ii,jj,kk,1) = merge(-0.6+(ii-6)*dx, merge( -1.0+(ii-1)*dx_s, 0.6+(ii-36)*dx_s, ii<6), ii>=6 .and. ii<=36)
+        vector_field(ii,jj,kk,2) = merge(-0.6+(jj-6)*dy, merge( -1.0+(jj-1)*dy_s, 0.6+(jj-36)*dy_s, jj<6), jj>=6 .and. jj<=36)
+        vector_field(ii,jj,kk,3) = -1.0+(kk-1)*dz
+        vector_field(ii,jj,kk,4) = merge(2.0, 1.0, (ii==1 .or. ii==nx .or. jj==1 .or. jj==ny .or. kk==1 .or. kk==nz))
       end do
     end associate
   end function

--- a/src/FD/tests/unit/test-adi-time-advancing.f90
+++ b/src/FD/tests/unit/test-adi-time-advancing.f90
@@ -21,7 +21,7 @@ module adi_mod
   integer(ikind)  :: i, j, k
   integer(ikind) ,parameter :: nx=41, ny=41, nz=41
 
-contains  
+contains
 
   pure function position_vectors(nx,ny,nz) result(vector_field)
     integer(ikind), intent(in) :: nx, ny, nz
@@ -379,12 +379,12 @@ program main
     t=t+dt
     end do
   end block time_advancing
-  
+
 !  analytical_solution: block
 !    real(rkind), dimension(:,:,:), allocatable :: a_mnl, k_mnl
 !    integer(ikind)                             :: l,m,n,kk,jj,ii
 !    real(rkind)                                :: pi, t
-  
+
     pi=4.0*atan(1.0)
     t=0.1
     allocate(a_mnl(10,10,10), k_mnl(10,10,10))
@@ -414,7 +414,7 @@ program main
       global_grid_block(i,j,k-1)%T_analytical(5)=global_grid_block(i,j,k)%T_analytical(1)
     end do
 !  end block analytical_solution
-  
+
 !  error_calculation: block
 !    real(rkind)            :: avg_err_percentage
 !    real(rkind), parameter :: err_percentage=0.1
@@ -427,7 +427,7 @@ program main
     avg_err_percentage=100*avg_err_percentage/((nz-1)*(ny-1)*(nx-1)*8)
     if (avg_err_percentage < 0.1) print *, "Test passed."
 !  end block error_calculation
-  
+
   call output_result(global_grid_block)
 
 end program main

--- a/src/FD/tests/unit/test-spatial-derivatives.f90
+++ b/src/FD/tests/unit/test-spatial-derivatives.f90
@@ -25,7 +25,6 @@ contains
 
   pure function position_vectors(nx,ny,nz) result(vector_field)
     integer(ikind), intent(in) :: nx, ny, nz
-    integer(ikind) :: ii, jj, kk
     integer(ikind), parameter :: components=3
     real(rkind), parameter :: dx=0.75/(5.0), dy=0.75/(5.0)
     real(rkind), parameter :: dx_s=0.25/5.0, dy_s=0.25/5.0
@@ -34,7 +33,7 @@ contains
     allocate( vector_field(nx,ny,nz,components) )
 
     associate( dz=>10.0/(nz-1) )
-      do concurrent( ii=1:nx, jj=1:ny, kk=1:nz )
+      do concurrent( i=1:nx, j=1:ny, k=1:nz )
         vector_field(i,j,k,1) = merge(-0.75+(i-6)*dx, merge( -1.0+(i-1)*dx_s, 0.75+(i-16)*dx_s, i<6), i>=6 .and. i<=16)
         vector_field(i,j,k,2) = merge(-0.75+(j-6)*dy, merge( -1.0+(j-1)*dy_s, 0.75+(j-16)*dy_s, j<6), j>=6 .and. j<=16)
         vector_field(i,j,k,3) = (k-1)*dz

--- a/src/FD/tests/unit/test-spatial-derivatives.f90
+++ b/src/FD/tests/unit/test-spatial-derivatives.f90
@@ -4,8 +4,9 @@
 !     under contract "Multi-Dimensional Physics Implementation into Fuel Analysis under
 !     Steady-state and Transients (FAST)", contract # NRC-HQ-60-17-C-0007
 !
-program main
+module adi_mod
   implicit none
+
   integer ,parameter :: digits=8  ! num. digits of kind
   integer ,parameter :: decades=9 ! num. representable decades
   integer ,parameter :: rkind = selected_real_kind(digits)
@@ -20,106 +21,11 @@ program main
   integer(ikind)  :: i,j,k
   integer(ikind) ,parameter :: nx=21, ny=21, nz=21
 
-  associate( p => position_vectors(nx,ny,nz) )
-
-    allocate(global_grid_block(nx-1,ny-1,nz-1))
-
-    associate( x=>(p(:,:,:,1)), y=>(p(:,:,:,2)), z=>(p(:,:,:,3)) )
-      do concurrent(k=1:nz-1, j=1:ny-1, i=1:nx-1)
-        associate( v=>global_grid_block(i,j,k)%v )
-          v(1,:) = [x(i,j,k)      , y(i,j,k)      , z(i,j,k)      ]
-          v(2,:) = [x(i+1,j,k)    , y(i+1,j,k)    , z(i+1,j,k)    ]
-          v(3,:) = [x(i,j+1,k)    , y(i,j+1,k)    , z(i,j+1,k)    ]
-          v(4,:) = [x(i+1,j+1,k)  , y(i+1,j+1,k)  , z(i+1,j+1,k)  ]
-          v(5,:) = [x(i,j,k+1)    , y(i,j,k+1)    , z(i,j,k+1)    ]
-          v(6,:) = [x(i+1,j,k+1)  , y(i+1,j,k+1)  , z(i+1,j,k+1)  ]
-          v(7,:) = [x(i,j+1,k+1)  , y(i,j+1,k+1)  , z(i,j+1,k+1)  ]
-          v(8,:) = [x(i+1,j+1,k+1), y(i+1,j+1,k+1), z(i+1,j+1,k+1)]
-          associate(T=>global_grid_block(i,j,k)%T, ddx2=>global_grid_block(i,j,k)%ddx2 )
-            T(:) = v(:,1)**2 * v(:,2) ! T=x^2*y => d^2T/dx^2=y
-            ddx2(:) = 0.0
-          end associate
-        end associate
-      end do
-    end associate
-  end associate
-
-  compute_derivatives: block
-    real(rkind), dimension(8) :: dx_m, dy_m, dz_m
-    real(rkind), dimension(8) :: dx_f, dy_f, dz_f
-    real(rkind), dimension(8) :: dx_b, dy_b, dz_b
-
-    do concurrent( k=2:nz-2, j=2:ny-2, i=2:nx-2)
-
-      !calculate ddx2
-      associate(v=>global_grid_block(i,j,k)%v , ddx2=>global_grid_block(i,j,k)%ddx2, &
-        T=>global_grid_block(i,j,k)%T,  ddy2=>global_grid_block(i,j,k)%ddy2, ddz2=>global_grid_block(i,j,k)%ddz2 )
-
-        associate(nv=>[1,3,5,7])
-          dx_m(nv) = 0.5*(v(nv+1,1) - global_grid_block(i-1,j,k)%v(nv,1))
-          dx_f(nv) =      v(nv+1,1) - v(nv,1)
-          dx_b(nv) =      v(nv,1)   - global_grid_block(i-1,j,k)%v(nv,1)
-          ddx2(nv) = (T(nv+1) - T(nv)  )/(dx_f(nv)*dx_m(nv)) - &
-          &          (T(nv)   - global_grid_block(i-1,j,k)%T(nv))/(dx_b(nv)*dx_m(nv))
-        end associate
-        associate(nv=>[2,4,6,8])
-          dx_m(nv) = 0.5*(global_grid_block(i+1,j,k)%v(nv,1) - v(nv-1,1))
-          dx_f(nv) =      global_grid_block(i+1,j,k)%v(nv,1) - v(nv,1)
-          dx_b(nv) =      global_grid_block(i,j,k)%v(nv,1)   - v(nv-1,1)
-          ddx2(nv) = ( global_grid_block(i+1,j,k)%T(nv) - T(nv) )/(dx_f(nv)*dx_m(nv)) - (T(nv) - T(nv-1))/(dx_b(nv)*dx_m(nv))
-        end associate
-
-        !calculate ddy2
-        associate(nv=>[1,2,5,6])
-          dy_m(nv)=0.5*(v(nv+2,2) - global_grid_block(i,j-1,k)%v(nv,2))
-          dy_f(nv)=v(nv+2,2) - v(nv,2)
-          dy_b(nv)=v(nv,2) - global_grid_block(i,j-1,k)%v(nv,2)
-          ddy2(nv)=(T(nv+2)-T(nv))/(dy_f(nv)*dy_m(nv)) - (T(nv)-global_grid_block(i,j-1,k)%T(nv))/(dy_b(nv)*dy_m(nv))
-        end associate
-
-        associate(nv=>[3,4,7,8])
-          dy_m(nv) =0.5*(global_grid_block(i,j+1,k)%v(nv,2) - v(nv-2,2))
-          dy_f(nv) =global_grid_block(i,j+1,k)%v(nv,2) - v(nv,2)
-          dy_b(nv) = v(nv,2) - v(nv-2,2)
-          ddy2(nv) = (global_grid_block(i,j+1,k)%T(nv) - T(nv))/(dy_f(nv)*dy_m(nv))- (T(nv) - T(nv-2))/(dy_b(nv)*dy_m(nv))
-        end associate
-
-        !calculate ddz2
-        associate(nv=>[1,2,3,4])
-          dz_m(nv)=0.5*(v(nv+4,3) - global_grid_block(i,j,k-1)%v(nv,3))
-          dz_f(nv)=v(nv+4,3) - v(nv,3)
-          dz_b(nv)=v(nv,3) - global_grid_block(i,j,k-1)%v(nv,3)
-          ddz2(nv)=(T(nv+4)- T(nv))/(dz_f(nv)*dz_m(nv)) - (T(nv) - global_grid_block(i,j,k-1)%T(nv))/(dz_b(nv)*dz_m(nv))
-        end associate
-
-        associate(nv=>[5,6,7,8])
-          dz_m(nv)=0.5*(global_grid_block(i,j,k+1)%v(nv,3)-v(nv-4,3))
-          dz_f(nv)=global_grid_block(i,j,k+1)%v(nv,3)-v(nv,3)
-          dz_b(nv)=v(nv,3)-v(nv-4,3)
-          ddz2(nv)=(global_grid_block(i,j,k+1)%T(nv)-T(nv))/(dz_f(nv)*dz_m(nv))- (T(nv)-T(nv-4))/(dz_b(nv)*dz_m(nv))
-        end associate
-      end associate
-    end do
-  end block compute_derivatives
-
-  error_calculation: block
-    real(rkind)            :: avg_err, minimum_dx
-    integer(ikind)         :: nv
-    minimum_dx=0.25/5.0
-    avg_err=0.0
-    do concurrent(k=2:nz-2,j=2:ny-2,i=2:nx-2,nv=1:8)
-      avg_err=avg_err+abs(global_grid_block(i,j,k)%ddx2(nv)-2.0*global_grid_block(i,j,k)%v(nv,2))
-    end do
-    avg_err=avg_err/((nz-3)*(ny-3)*(nx-3)*8)
-    if (avg_err <= minimum_dx**2) print *, "Test passed."
-  end block error_calculation
-
-  call output_result(global_grid_block)
-
 contains
 
   pure function position_vectors(nx,ny,nz) result(vector_field)
     integer(ikind), intent(in) :: nx, ny, nz
+    integer(ikind) :: ii, jj, kk
     integer(ikind), parameter :: components=3
     real(rkind), parameter :: dx=0.75/(5.0), dy=0.75/(5.0)
     real(rkind), parameter :: dx_s=0.25/5.0, dy_s=0.25/5.0
@@ -128,7 +34,7 @@ contains
     allocate( vector_field(nx,ny,nz,components) )
 
     associate( dz=>10.0/(nz-1) )
-      do concurrent( i=1:nx, j=1:ny, k=1:nz )
+      do concurrent( ii=1:nx, jj=1:ny, kk=1:nz )
         vector_field(i,j,k,1) = merge(-0.75+(i-6)*dx, merge( -1.0+(i-1)*dx_s, 0.75+(i-16)*dx_s, i<6), i>=6 .and. i<=16)
         vector_field(i,j,k,2) = merge(-0.75+(j-6)*dy, merge( -1.0+(j-1)*dy_s, 0.75+(j-16)*dy_s, j<6), j>=6 .and. j<=16)
         vector_field(i,j,k,3) = (k-1)*dz
@@ -219,4 +125,112 @@ contains
     end block
   end subroutine output_result
 
-end program
+end module adi_mod
+
+program main
+  use adi_mod
+  implicit none
+
+  real(rkind), dimension(8) :: dx_m, dy_m, dz_m
+  real(rkind), dimension(8) :: dx_f, dy_f, dz_f
+  real(rkind), dimension(8) :: dx_b, dy_b, dz_b
+  real(rkind)               :: avg_err, minimum_dx
+  integer(ikind)            :: nv
+
+  associate( p => position_vectors(nx,ny,nz) )
+
+    allocate(global_grid_block(nx-1,ny-1,nz-1))
+
+    associate( x=>(p(:,:,:,1)), y=>(p(:,:,:,2)), z=>(p(:,:,:,3)) )
+      do concurrent(k=1:nz-1, j=1:ny-1, i=1:nx-1)
+        associate( v=>global_grid_block(i,j,k)%v )
+          v(1,:) = [x(i,j,k)      , y(i,j,k)      , z(i,j,k)      ]
+          v(2,:) = [x(i+1,j,k)    , y(i+1,j,k)    , z(i+1,j,k)    ]
+          v(3,:) = [x(i,j+1,k)    , y(i,j+1,k)    , z(i,j+1,k)    ]
+          v(4,:) = [x(i+1,j+1,k)  , y(i+1,j+1,k)  , z(i+1,j+1,k)  ]
+          v(5,:) = [x(i,j,k+1)    , y(i,j,k+1)    , z(i,j,k+1)    ]
+          v(6,:) = [x(i+1,j,k+1)  , y(i+1,j,k+1)  , z(i+1,j,k+1)  ]
+          v(7,:) = [x(i,j+1,k+1)  , y(i,j+1,k+1)  , z(i,j+1,k+1)  ]
+          v(8,:) = [x(i+1,j+1,k+1), y(i+1,j+1,k+1), z(i+1,j+1,k+1)]
+          associate(T=>global_grid_block(i,j,k)%T, ddx2=>global_grid_block(i,j,k)%ddx2 )
+            T(:) = v(:,1)**2 * v(:,2) ! T=x^2*y => d^2T/dx^2=y
+            ddx2(:) = 0.0
+          end associate
+        end associate
+      end do
+    end associate
+  end associate
+
+!  compute_derivatives: block
+!    real(rkind), dimension(8) :: dx_m, dy_m, dz_m
+!    real(rkind), dimension(8) :: dx_f, dy_f, dz_f
+!    real(rkind), dimension(8) :: dx_b, dy_b, dz_b
+
+    do concurrent( k=2:nz-2, j=2:ny-2, i=2:nx-2)
+
+      !calculate ddx2
+      associate(v=>global_grid_block(i,j,k)%v , ddx2=>global_grid_block(i,j,k)%ddx2, &
+        T=>global_grid_block(i,j,k)%T,  ddy2=>global_grid_block(i,j,k)%ddy2, ddz2=>global_grid_block(i,j,k)%ddz2 )
+
+        associate(nv=>[1,3,5,7])
+          dx_m(nv) = 0.5*(v(nv+1,1) - global_grid_block(i-1,j,k)%v(nv,1))
+          dx_f(nv) =      v(nv+1,1) - v(nv,1)
+          dx_b(nv) =      v(nv,1)   - global_grid_block(i-1,j,k)%v(nv,1)
+          ddx2(nv) = (T(nv+1) - T(nv)  )/(dx_f(nv)*dx_m(nv)) - &
+          &          (T(nv)   - global_grid_block(i-1,j,k)%T(nv))/(dx_b(nv)*dx_m(nv))
+        end associate
+        associate(nv=>[2,4,6,8])
+          dx_m(nv) = 0.5*(global_grid_block(i+1,j,k)%v(nv,1) - v(nv-1,1))
+          dx_f(nv) =      global_grid_block(i+1,j,k)%v(nv,1) - v(nv,1)
+          dx_b(nv) =      global_grid_block(i,j,k)%v(nv,1)   - v(nv-1,1)
+          ddx2(nv) = ( global_grid_block(i+1,j,k)%T(nv) - T(nv) )/(dx_f(nv)*dx_m(nv)) - (T(nv) - T(nv-1))/(dx_b(nv)*dx_m(nv))
+        end associate
+
+        !calculate ddy2
+        associate(nv=>[1,2,5,6])
+          dy_m(nv)=0.5*(v(nv+2,2) - global_grid_block(i,j-1,k)%v(nv,2))
+          dy_f(nv)=v(nv+2,2) - v(nv,2)
+          dy_b(nv)=v(nv,2) - global_grid_block(i,j-1,k)%v(nv,2)
+          ddy2(nv)=(T(nv+2)-T(nv))/(dy_f(nv)*dy_m(nv)) - (T(nv)-global_grid_block(i,j-1,k)%T(nv))/(dy_b(nv)*dy_m(nv))
+        end associate
+
+        associate(nv=>[3,4,7,8])
+          dy_m(nv) =0.5*(global_grid_block(i,j+1,k)%v(nv,2) - v(nv-2,2))
+          dy_f(nv) =global_grid_block(i,j+1,k)%v(nv,2) - v(nv,2)
+          dy_b(nv) = v(nv,2) - v(nv-2,2)
+          ddy2(nv) = (global_grid_block(i,j+1,k)%T(nv) - T(nv))/(dy_f(nv)*dy_m(nv))- (T(nv) - T(nv-2))/(dy_b(nv)*dy_m(nv))
+        end associate
+
+        !calculate ddz2
+        associate(nv=>[1,2,3,4])
+          dz_m(nv)=0.5*(v(nv+4,3) - global_grid_block(i,j,k-1)%v(nv,3))
+          dz_f(nv)=v(nv+4,3) - v(nv,3)
+          dz_b(nv)=v(nv,3) - global_grid_block(i,j,k-1)%v(nv,3)
+          ddz2(nv)=(T(nv+4)- T(nv))/(dz_f(nv)*dz_m(nv)) - (T(nv) - global_grid_block(i,j,k-1)%T(nv))/(dz_b(nv)*dz_m(nv))
+        end associate
+
+        associate(nv=>[5,6,7,8])
+          dz_m(nv)=0.5*(global_grid_block(i,j,k+1)%v(nv,3)-v(nv-4,3))
+          dz_f(nv)=global_grid_block(i,j,k+1)%v(nv,3)-v(nv,3)
+          dz_b(nv)=v(nv,3)-v(nv-4,3)
+          ddz2(nv)=(global_grid_block(i,j,k+1)%T(nv)-T(nv))/(dz_f(nv)*dz_m(nv))- (T(nv)-T(nv-4))/(dz_b(nv)*dz_m(nv))
+        end associate
+      end associate
+    end do
+!  end block compute_derivatives
+
+!  error_calculation: block
+!    real(rkind)            :: avg_err, minimum_dx
+!    integer(ikind)         :: nv
+    minimum_dx=0.25/5.0
+    avg_err=0.0
+    do concurrent(k=2:nz-2,j=2:ny-2,i=2:nx-2,nv=1:8)
+      avg_err=avg_err+abs(global_grid_block(i,j,k)%ddx2(nv)-2.0*global_grid_block(i,j,k)%v(nv,2))
+    end do
+    avg_err=avg_err/((nz-3)*(ny-3)*(nx-3)*8)
+    if (avg_err <= minimum_dx**2) print *, "Test passed."
+!  end block error_calculation
+
+  call output_result(global_grid_block)
+
+end program main


### PR DESCRIPTION
First set of Windows w/ Intel 18.0.5 workarounds. It does not like the `abstract interface`. In removing that, I had to also make the `deferred` procedures no longer be explicitly `private`.