### PR TITLE
Fix fd vtkmofo

### DIFF
--- a/src/FD/CMakeLists.txt
+++ b/src/FD/CMakeLists.txt
@@ -240,7 +240,7 @@ set( base_names
   plate-material-mapping
   discretize-3D-plate
   write-slab-vtk
-  write-vtk-voxels
+  write-voxels-vtk
 )
 foreach(integration_test ${base_names})
   add_caf_test( fd-${integration_test} 1 ${CMAKE_CURRENT_BINARY_DIR}/tests/integration/test-${integration_test}

--- a/src/FD/grid/problem_discretization_implementation.F90
+++ b/src/FD/grid/problem_discretization_implementation.F90
@@ -31,11 +31,11 @@ contains
     suffix = file_extension( file_name )
     select case(suffix)
       case('csv')
-        call csv_output
+        call csv_output (this, file_name, unit, iostat)
       case('vtk')
-        CALL VTK_output
+        call VTK_output (this, file_name, iostat)
       case('json')
-        CALL json_output
+        call json_output (this, file_name, iostat)
       case default
         error stop "problem_discretization%write_formatted: unsupported file name extension" // &
 #ifdef HAVE_NON_CONSTANT_ERROR_STOP
@@ -45,114 +45,153 @@ contains
 #endif
       end select
 
-    contains
-
-      subroutine json_output
-        error stop "json_output: not yet implemented"
-      end subroutine
-
-      subroutine csv_output
-        integer ix,iy,iz
-        associate( nx=>this%global_block_shape_(1), ny=>this%global_block_shape_(2), nz=>this%global_block_shape_(3) )
-          write(unit,'(4("      ",a,:,",",5x))') "x","y","z","layer (phony)"
-          write(unit,*) new_line('a')
-          do iz=1,nz
-            do iy=1,ny
-              do ix=1,nx
-#ifdef HAVE_UDDTIO
-                write(unit,*) this%vertices( this%block_identifier([ix,iy,iz])  )
-#else
-                CALL this%vertices( this%block_identifier([ix,iy,iz])  )%write_formatted(unit,iotype, v_list, iostat, iomsg)
-#endif
-              end do
-            end do
-          end do
-        end associate
-      end subroutine
-
-      SUBROUTINE define_scalar( s, vals, dataname )
-          USE vtk_attributes, ONLY : scalar, attributes
-          CLASS(attributes), INTENT(INOUT) :: s
-          REAL(r8k),         INTENT(IN)    :: vals(:)
-          CHARACTER(LEN=*),  INTENT(IN)    :: dataname
-
-          IF (.NOT. ALLOCATED(s%attribute)) ALLOCATE(scalar::s%attribute)
-          CALL s%attribute%init (dataname, numcomp=1, real1d=vals)
-      END SUBROUTINE
-
-      SUBROUTINE  VTK_output
-            USE vtk_datasets,   ONLY : unstruct_grid
-            USE vtk,            ONLY : vtk_serial_write
-            USE vtk_cells, ONLY : voxel, vtkcell_list
-            USE vtk_attributes, ONLY : attributes
-            USE array_functions_interface, ONLY : OPERATOR(.catColumns.), OPERATOR(.columnVectors.)
-            TYPE(voxel) :: voxel_cell  !! Voxel cell type
-            TYPE(vtkcell_list), DIMENSION(:), ALLOCATABLE :: cell_list !! Full list of all cells
-            TYPE (unstruct_grid) :: vtk_grid
-            INTEGER(i4k) :: ip, jp, kp !! block-local point id
-            INTEGER(i4k) :: ic, jc, kc !! block-local cell id
-            REAL(r8k), DIMENSION(:,:), ALLOCATABLE :: points
-            INTEGER(i4k), DIMENSION(:), ALLOCATABLE :: block_point_tag, block_cell_tag
-            TYPE(attributes) :: point_values, cell_values
-            INTEGER :: b, first_point_in_block, first_cell_in_block
-            INTEGER, PARAMETER :: vector_indices=4, writer=1
-
-            CALL assert(this_image()==writer, "problem_discretization%write_formatted: output from image 1")
-
-            ALLOCATE( cell_list(SUM( this%vertices%num_cells())) )
-            ALLOCATE( points(space_dimensions,0), block_point_tag(0), block_cell_tag(0) )
-
-            first_point_in_block = 0
-            first_cell_in_block = 1
-
-            loop_over_grid_blocks: DO b=lbound(this%vertices,1), ubound(this%vertices,1)
-
-              ASSOCIATE( vertex_positions => this%vertices(b)%vectors() ) !! 4D array of nodal position vectors
-                ASSOCIATE( npoints => shape(vertex_positions(:,:,:,1)) )  !! shape of 1st 3 dims specifies # points in ea. direction
-                  ASSOCIATE( ncells => npoints-1 )
-
-                    points = points .catColumns. ( .columnVectors. vertex_positions )
-                    block_point_tag = [ block_point_tag, first_point_in_block + [( ip, ip=1, PRODUCT(npoints) )] ]
-                    block_cell_tag = [ block_cell_tag, (this%vertices(b)%get_tag(), ic=1,PRODUCT(ncells)) ]
-
-                    DO ic=1,ncells(1)
-                      DO jc=1,ncells(2)
-                        DO kc=1,ncells(3)
-                          ASSOCIATE( block_local_point_id => & !! 8-element array of block-local ID's for voxel corners
-                            [( [( [( kp*PRODUCT(npoints(1:2)) + jp*npoints(1) + ip, ip=ic,ic+1 )], jp=jc-1,jc )], kp=kc-1,kc )] &
-                          )
-                            CALL voxel_cell%setup ( first_point_in_block + block_local_point_id-1 )
-                          END ASSOCIATE
-                          ASSOCIATE( local_cell_id => (kc-1)*PRODUCT(ncells(1:2)) + (jc-1)*ncells(1) + ic )
-                            ASSOCIATE(  cell_id => first_cell_in_block + local_cell_id - 1 )
-                              ALLOCATE(cell_list(cell_id)%cell, source=voxel_cell)!GCC8 workaround for cell_list(i)%cell= voxel_cell
-                            END ASSOCIATE
-                          END ASSOCIATE
-                        END DO
-                      END DO
-                    END DO
-
-                    first_cell_in_block  = first_cell_in_block  + PRODUCT( ncells  )
-                    first_point_in_block = first_point_in_block + PRODUCT( npoints )
-                  END ASSOCIATE
-                END ASSOCIATE
-              END ASSOCIATE
-            END DO loop_over_grid_blocks
-
-            CALL assert( SIZE(block_point_tag,1) == SIZE(points,2), "VTK point data set & point set size match" )
-            CALL assert( SIZE(block_cell_tag,1) == SIZE(cell_list,1), "VTK cell data set & cell set size match" )
-
-            CALL define_scalar(  point_values, REAL( block_point_tag, r8k),  'point_tag' )
-            CALL define_scalar(  cell_values, REAL( block_cell_tag, r8k),  'cell_tag' )
-
-            CALL vtk_grid%init (points=points, cell_list=cell_list )
-            CALL vtk_serial_write( &
-              unit=unit, geometry=vtk_grid, title='Morfeus-FD voxels', multiple_io=.TRUE., &
-              celldatasets=[cell_values], pointdatasets=[point_values] )
-
-        END SUBROUTINE VTK_output
-
   end procedure write_formatted
+
+  subroutine json_output (this, filename, iostat)
+    class(problem_discretization), intent(in) ::this
+    character(LEN=*), intent(in) :: filename
+    integer, intent(inout), optional :: iostat
+    error stop "json_output: not yet implemented"
+  end subroutine
+
+  subroutine csv_output (this, filename, unit, iostat)
+    class(problem_discretization), intent(in) ::this
+    character(len=*), intent(in) :: filename
+    integer, intent(in), optional :: unit
+    integer, intent(inout), optional :: iostat
+    character(len=132) :: iomsg
+    integer, dimension(0) :: v_list
+    integer ix,iy,iz
+    associate( nx=>this%global_block_shape_(1), ny=>this%global_block_shape_(2), nz=>this%global_block_shape_(3) )
+      write(unit,'(4("      ",a,:,",",5x))') "x","y","z","layer (phony)"
+      write(unit,*) new_line('a')
+      do iz=1,nz
+        do iy=1,ny
+          do ix=1,nx
+#ifdef HAVE_UDDTIO
+            write(unit,*) this%vertices( this%block_identifier([ix,iy,iz])  )
+#else
+            call this%vertices( this%block_identifier([ix,iy,iz]) )%write_formatted(unit,'DT', v_list, iostat, iomsg)
+#endif
+          end do
+        end do
+      end do
+    end associate
+  end subroutine
+
+  subroutine define_scalar( s, vals, dataname )
+    use vtk_attributes, only : scalar, attributes
+    implicit none
+    class(attributes), intent(INOUT) :: s
+    real(r8k),         intent(in)    :: vals(:)
+    character(LEN=*),  intent(in)    :: dataname
+
+    if (.NOT. allocateD(s%attribute)) allocate(scalar::s%attribute)
+    call s%attribute%init (dataname, numcomp=1, real1d=vals)
+  end subroutine
+
+subroutine VTK_output (this, filename, iostat)
+      use vtk_datasets,   only : unstruct_grid
+      use vtk,            only : vtk_serial_write
+      use vtk_cells, only : voxel, vtkcell_list
+      use vtk_attributes, only : attributes
+      use array_functions_interface, only : OPERATOR(.catColumns.), OPERATOR(.columnVectors.)
+      implicit none
+      class(problem_discretization), intent(in) ::this
+      character(LEN=*), intent(in), optional :: filename
+      integer, intent(out) :: iostat
+      type(voxel) :: voxel_cell  !! Voxel cell type
+      type(vtkcell_list), dimension(:), allocatable :: cell_list !! Full list of all cells
+      type (unstruct_grid) :: vtk_grid
+      integer(i4k) :: ip, jp, kp !! block-local point id
+      integer(i4k) :: ic, jc, kc !! block-local cell id
+      real(r8k), dimension(:,:), allocatable :: points
+      integer(i4k), dimension(:), allocatable :: block_point_tag, block_cell_tag
+      type(attributes) :: point_values, cell_values
+      integer :: b, first_point_in_block, first_cell_in_block
+      integer, PARAMETER :: vector_indices=4, writer=1
+
+      call assert(this_image()==writer, "problem_discretization%write_formatted: output from image 1")
+
+      allocate( cell_list(SUM( this%vertices%num_cells())) )
+      allocate( points(space_dimensions,0), block_point_tag(0), block_cell_tag(0) )
+
+      first_point_in_block = 0
+      first_cell_in_block = 1
+
+      loop_over_grid_blocks: do b=lbound(this%vertices,1), ubound(this%vertices,1)
+
+        associate( vertex_positions => this%vertices(b)%vectors() ) !! 4D array of nodal position vectors
+          associate( npoints => shape(vertex_positions(:,:,:,1)) )  !! shape of 1st 3 dims specifies # points in ea. direction
+            associate( ncells => npoints-1 )
+
+              points = points .catColumns. ( .columnVectors. vertex_positions )
+              block_point_tag = [ block_point_tag, first_point_in_block + [( ip, ip=1, PRODUCT(npoints) )] ]
+              block_cell_tag = [ block_cell_tag, (this%vertices(b)%get_tag(), ic=1,PRODUCT(ncells)) ]
+
+              do ic=1,ncells(1)
+                do jc=1,ncells(2)
+                  do kc=1,ncells(3)
+                    associate( block_local_point_id => & !! 8-element array of block-local ID's for voxel corners
+                      [( [( [( kp*PRODUCT(npoints(1:2)) + jp*npoints(1) + ip, ip=ic,ic+1 )], jp=jc-1,jc )], kp=kc-1,kc )] &
+                    )
+                      call voxel_cell%setup ( first_point_in_block + block_local_point_id-1 )
+                    end associate
+                    associate( local_cell_id => (kc-1)*PRODUCT(ncells(1:2)) + (jc-1)*ncells(1) + ic )
+                      associate(  cell_id => first_cell_in_block + local_cell_id - 1 )
+                        allocate(cell_list(cell_id)%cell, source=voxel_cell)!GCC8 workaround for cell_list(i)%cell= voxel_cell
+                      end associate
+                    end associate
+                  end do
+                end do
+              end do
+
+              first_cell_in_block  = first_cell_in_block  + PRODUCT( ncells  )
+              first_point_in_block = first_point_in_block + PRODUCT( npoints )
+            end associate
+          end associate
+        end associate
+      end do loop_over_grid_blocks
+
+      call assert( SIZE(block_point_tag,1) == SIZE(points,2), "VTK point data set & point set size match" )
+      call assert( SIZE(block_cell_tag,1) == SIZE(cell_list,1), "VTK cell data set & cell set size match" )
+
+      call define_scalar(  point_values, real( block_point_tag, r8k),  'point_tag' )
+      call define_scalar(  cell_values, real( block_cell_tag, r8k),  'cell_tag' )
+
+      call vtk_grid%init (points=points, cell_list=cell_list )
+      call vtk_serial_write(filename=filename, geometry=vtk_grid, multiple_io=.TRUE., &
+        &                   celldatasets=[cell_values], pointdatasets=[point_values] )
+      iostat = 0
+  end subroutine VTK_output
+
+  module procedure write_output
+    implicit none
+    !! author: Ian Porter
+    !! date: 11/25/2019
+    !!
+    !! This is a generic procedure for writing output files. This procedure eliminates the DTIO
+    !! to allow for linking to external libraries that handle all of the file output
+    !!
+    integer :: iostat
+    iostat = 0
+    select case (filetype)
+    case ('vtk')
+      call vtk_output (this, filename, iostat)
+    case ('csv')
+      call csv_output (this, filename, iostat)
+    case ('json')
+     call json_output (this, filename, iostat)
+   case default
+     error stop "problem_discretization%write_output: unsupported file type" // &
+#ifdef HAVE_NON_CONSTANT_ERROR_STOP
+     & filename ! Fortran 2018
+#else
+     & "."       ! Fortran 2008
+#endif
+   end select
+
+  end procedure write_output
 
   pure function evenly_spaced_points( boundaries, resolution, direction ) result(grid_nodes)
     !! Define grid point coordinates with uniform spacing in the chosen subdomain
@@ -172,7 +211,7 @@ contains
     integer ix,iy,iz
 
     allocate(grid_nodes(resolution(1),resolution(2),resolution(3)), stat=alloc_status, errmsg=alloc_error )
-    CALL assert( alloc_status==success, "evenly_spaced_points allocation ("//alloc_error//")", PRODUCT(resolution) )
+    call assert( alloc_status==success, "evenly_spaced_points allocation ("//alloc_error//")", PRODUCT(resolution) )
 
     associate( num_intervals => resolution - 1 )
       dx = ( boundaries(:,up_bound) - boundaries(:,lo_bound) ) / num_intervals(:)
@@ -216,7 +255,7 @@ contains
       !! partition a block-structured grid into subdomains with connectivity implied by the indexing of the 3D array of blocks
 
       associate( my_subdomains => this%my_subdomains() )
-        do n = my_subdomains(lo_bound) , my_subdomains(up_bound) ! TODO: make concurrent after Intel supports co_sum
+        do n = my_subdomains(lo_bound) , my_subdomains(up_bound) ! TOdo: make concurrent after Intel supports co_sum
 
           associate( ijk => this%block_indicial_coordinates(n) )
 
@@ -272,7 +311,7 @@ contains
     if (assertions) then
       call assert(alloc_status==0,"partition: data distribution established")
       block
-#ifndef HAVE_COLLECTIVE_SUBROUTINES
+#ifndef HAVE_COLLECTIVE_subroutineS
         use emulated_intrinsics_interface, only : co_sum
 #endif
         integer total_blocks

--- a/src/FD/grid/problem_discretization_implementation.F90
+++ b/src/FD/grid/problem_discretization_implementation.F90
@@ -82,7 +82,7 @@ contains
 
       SUBROUTINE  VTK_output
             USE vtk_datasets,   ONLY : unstruct_grid
-            USE vtk,            ONLY : vtk_legacy_write
+            USE vtk,            ONLY : vtk_serial_write
             USE vtk_cells, ONLY : voxel, vtkcell_list
             USE vtk_attributes, ONLY : attributes
             USE array_functions_interface, ONLY : OPERATOR(.catColumns.), OPERATOR(.columnVectors.)
@@ -146,7 +146,7 @@ contains
             CALL define_scalar(  cell_values, REAL( block_cell_tag, r8k),  'cell_tag' )
 
             CALL vtk_grid%init (points=points, cell_list=cell_list )
-            CALL vtk_legacy_write( &
+            CALL vtk_serial_write( &
               unit=unit, geometry=vtk_grid, title='Morfeus-FD voxels', multiple_io=.TRUE., &
               celldatasets=[cell_values], pointdatasets=[point_values] )
 

--- a/src/FD/grid/problem_discretization_interface.F90
+++ b/src/FD/grid/problem_discretization_interface.F90
@@ -38,6 +38,7 @@ module problem_discretization_interface
 #ifdef HAVE_UDDTIO
     generic :: write(formatted) => write_formatted
 #endif
+    procedure :: write_output
   end type
 
   interface
@@ -50,6 +51,14 @@ module problem_discretization_interface
       character (len=*), intent(in) :: iotype
       integer, intent(out) :: iostat
       character(len=*), intent(inout) :: iomsg
+    end subroutine
+
+    module subroutine write_output (this, filename, filetype)
+      !! Generic write output interface
+      implicit none
+      class(problem_discretization), intent(in) ::this
+      character (len=*), intent(in) :: filename
+      character (len=*), intent(in) :: filetype
     end subroutine
 
     module subroutine initialize_from_plate_3D(this,plate_3D_geometry)

--- a/src/FD/tests/integration/CMakeLists.txt
+++ b/src/FD/tests/integration/CMakeLists.txt
@@ -8,7 +8,7 @@ set( base_names
   plate-material-mapping
   discretize-3D-plate
   write-slab-vtk
-  write-vtk-voxels
+  write-voxels-vtk
 )
 foreach(integration_test ${base_names})
   add_executable( test-${integration_test} test-${integration_test}.F90 )

--- a/src/FD/tests/integration/test-discretize-3D-plate.F90
+++ b/src/FD/tests/integration/test-discretize-3D-plate.F90
@@ -14,43 +14,23 @@ program main
   use problem_discretization_interface, only : problem_discretization
   implicit none
 
-  call create_grid_for_plate(input="3Dplate-low-resolution-layers.json", output="3Dplate-low-resolution-layers.vtk")
-  call create_grid_for_plate(input="3Dplate-high-resolution-layers.json", output="3Dplate-high-resolution-layers.vtk")
+  call create_grid_for_plate(input="3Dplate-low-resolution-layers.json", output="3Dplate-low-resolution-layers")
+  call create_grid_for_plate(input="3Dplate-high-resolution-layers.json", output="3Dplate-high-resolution-layers")
 
   print *,"Test passed."
 
 contains
 
-  subroutine output_grid( mesh, file_unit )
-    type(problem_discretization) :: mesh
-    integer file_unit
-
-#ifdef HAVE_UDDTIO
-    write(file_unit,*) mesh
-#else
-    block
-      integer, dimension(0) :: v_list
-      character(len=132) io_message
-      integer io_status
-      call mesh%write_formatted (file_unit, 'DT', v_list, io_status, io_message)
-    end block
-#endif
-  end subroutine
-
   subroutine create_grid_for_plate( input, output)
+    implicit none
     character(len=*), intent(in) :: input, output
     type(plate_3D) :: plate_geometry
     type(problem_discretization) :: global_grid
-    integer file_unit, open_status
-    integer, parameter :: success=0
 
     call plate_geometry%build( input ) !! read geometrical information
     call global_grid%initialize_from_geometry( plate_geometry ) !! partition block-structured grid & define grid vertex locations
 
-    open(newunit=file_unit, file=output, iostat=open_status)
-    call assert(open_status==success, output//" opened succesfully")
-
-    call output_grid( global_grid, file_unit)
+    call global_grid%write_output (output, 'vtk') !! TODO. Make more sophisticated to allow calling of other output types
 
   end subroutine
 

--- a/src/FD/tests/integration/test-plate-material-mapping.F90
+++ b/src/FD/tests/integration/test-plate-material-mapping.F90
@@ -20,14 +20,14 @@ program main
   type(problem_discretization) global_grid
   integer file_unit, open_status
   integer, parameter :: success=0
-  character(len=*), parameter :: output_file="3Dplate-low-resolution-layers-material-map.vtk"
-  character(len=*), parameter :: input_file="3Dplate-low-resolution-layers-material-map.json"
+  character(len=*), parameter :: output = "3Dplate-low-resolution-layers-material-map"
+  character(len=*), parameter :: input = "3Dplate-low-resolution-layers-material-map.json"
 
-  call plate_geometry%build( input_file )
+  call plate_geometry%build( input )
   call global_grid%initialize_from_geometry( plate_geometry ) !! partition block-structured grid & define grid vertex locations
 
-  open(newunit=file_unit, file=output_file, iostat=open_status)
-  call assert(open_status==success, output_file//" opened succesfully")
+!  open(newunit=file_unit, file=output_file, iostat=open_status)
+!  call assert(open_status==success, output_file//" opened succesfully")
 
   check_metadata: block
     character(len=max_name_length), allocatable :: map(:,:,:)
@@ -49,27 +49,11 @@ program main
     end do
   end block check_metadata
 
-  call output_grid( global_grid, file_unit )
+  call global_grid%write_output (output, 'vtk') !! TODO. Make more sophisticated to allow calling of other output types
 
   print *,"Test passed."
 
 contains
-
-  subroutine output_grid( mesh, file_unit )
-    type(problem_discretization) :: mesh
-    integer file_unit
-
-#ifdef HAVE_UDDTIO
-    write(file_unit,*) mesh
-#else
-    block
-      integer, dimension(0) :: v_list
-      character(len=132) io_message
-      integer io_status
-      call mesh%write_formatted (file_unit, 'DT', v_list, io_status, io_message)
-    end block
-#endif
-  end subroutine
 
   function expected_map() result(material_map)
     character(len=max_name_length), allocatable :: material_map(:,:,:)

--- a/src/FD/tests/integration/test-write-voxels-vtk.F90
+++ b/src/FD/tests/integration/test-write-voxels-vtk.F90
@@ -10,7 +10,7 @@ PROGRAM T_shape_test
     !!
     !! Write a T-shaped, unstructured-grid geometry defined in VTK voxels
     USE kind_parameters, ONLY : i4k, r8k
-    USE vtk_datasets,   ONLY : unstruct_grid
+    USE vtk_datasets,    ONLY : unstruct_grid
     IMPLICIT NONE
     TYPE (unstruct_grid)  :: t_shape
     INTEGER(i4k), PARAMETER :: n_points = 24, n_cells = 5
@@ -54,7 +54,7 @@ PROGRAM T_shape_test
         CALL voxel_cells(4)%setup ( [ 9, 10, 13, 14, 17, 18, 21, 22 ] )
         CALL voxel_cells(5)%setup ( [ 10, 11, 14, 15, 18, 19, 22, 23 ] )
 
-        DO i=1,SIZE(voxel_cells)                               !! workaround gfortran 8.3.0 bug
+        DO i=1,SIZE(voxel_cells)                                 !! workaround gfortran 8.3.0 bug
             ALLOCATE(cell_list(i)%cell, source=voxel_cells(i))   !! Alternative: cell_list(i)%cell = voxel_cells(i)
         END DO
 
@@ -63,7 +63,7 @@ PROGRAM T_shape_test
 
     BLOCK
         !! Defne scalar quantities and write grid
-        USE vtk, ONLY : vtk_legacy_write
+        USE vtk, ONLY : vtk_serial_write
         USE vtk_attributes, ONLY : attributes
         TYPE (attributes) :: cell_vals_to_write, point_vals_to_write
         INTEGER(i4k) :: j
@@ -73,13 +73,12 @@ PROGRAM T_shape_test
         CALL define_scalar(  cell_vals_to_write, REAL( cell_ID, r8k),  'Cell_ID' )
         CALL define_scalar( point_vals_to_write, REAL(point_ID, r8k), 'Point_ID' )
 
-        CALL vtk_legacy_write (                  &
+        CALL vtk_serial_write (                  &
             t_shape,                             &
             celldatasets=[cell_vals_to_write],   &
             pointdatasets=[point_vals_to_write], &
-            filename='t_shape-voxels.vtk',       &
-            title='T-shaped voxel grid',         &
-            multiple_io=.TRUE.)
+            filename='test-write-voxels',        &
+            multiple_io=.FALSE.)
     END BLOCK
 
     WRITE(*,*) 'Test passed.'


### PR DESCRIPTION
Updates to use the new `vtk` format per contract requirements.

These changes eliminate the use of DTIO (Note: the TBPs for DTIO were not deleted). The updated `vtk` library handles all of the file i/o (including the opening / closing of the `vtk` files) so DTIO is not the best way to handle this.  This may prove useful for the next tasks of writing `exodus` and `hdf5` output files, in case the libraries themselves handle all of the file I/O.