### PR TITLE
WIP: Intel 18.0.5 Windows Fixes

### DIFF
--- a/src/FD/grid/problem_discretization_implementation.F90
+++ b/src/FD/grid/problem_discretization_implementation.F90
@@ -219,8 +219,10 @@ contains
     integer, parameter :: lo_bound=1, up_bound=2 !! array indices corresponding to end points on 1D spatial interval
     integer, parameter :: nx_min=2, ny_min=2, nz_min=2
     integer n
+    type(cartesian_grid) prototype
+      !! pass the cartesian_grid type
 
-    call this%partition( plate_3D_geometry%get_block_metadata_shape(), cartesian_grid() )
+    call this%partition( plate_3D_geometry%get_block_metadata_shape(), prototype )
       !! partition a block-structured grid into subdomains with connectivity implied by the indexing of the 3D array of blocks
 
       associate( my_subdomains => this%my_subdomains() )

--- a/src/FD/grid/problem_discretization_interface.F90
+++ b/src/FD/grid/problem_discretization_interface.F90
@@ -9,6 +9,7 @@ module problem_discretization_interface
   use structured_grid_interface, only : structured_grid
   use geometry_interface, only : geometry
   use kind_parameters, only : r8k, i4k
+  use plate_3D_interface, only : plate_3D
   implicit none
 
   private
@@ -68,14 +69,13 @@ module problem_discretization_interface
     end subroutine
 
     module subroutine initialize_from_plate_3D(this,plate_3D_geometry)
-      use plate_3D_interface, only : plate_3D
       !! Define a grid with points only at the corners of each structured-grid block subdomain
       implicit none
       class(problem_discretization), intent(inout) :: this
       type(plate_3D), intent(in) :: plate_3D_geometry
     end subroutine
 
-    module subroutine partition(this,global_block_shape, prototype)
+    module subroutine partition(this,global_block_shape,prototype)
       !! Define the distribution of subdomains across images for the given shape of the block-structured partitions
       !! (impure because of image-control statement in emulated co_sum -- may be pure when replaced by intrinsic co_sum)
       implicit none

--- a/src/FD/grid/structured_grid_interface.F90
+++ b/src/FD/grid/structured_grid_interface.F90
@@ -67,9 +67,10 @@ module structured_grid_interface
     !! of structured_grid objects.
 
   abstract interface
-    module function div_scalar_flux_interface(this, vertices, diffusion_coefficient) result(div_flux)
-     class(structured_grid), intent(in) :: this, vertices, diffusion_coefficient
-     class(structured_grid), allocatable :: div_flux
+    function div_scalar_flux_interface(this, vertices, diffusion_coefficient) result(div_flux)
+      import structured_grid
+      class(structured_grid), intent(in) :: this, vertices, diffusion_coefficient
+      class(structured_grid), allocatable :: div_flux
     end function
   end interface
 

--- a/src/FD/tests/unit/test-block-structure.f90
+++ b/src/FD/tests/unit/test-block-structure.f90
@@ -14,6 +14,8 @@ program main
 
   type(problem_discretization) block_structured_grid
     !! encapsulate the global grid structure
+  type(cartesian_grid) prototype
+    !! pass the cartesian_grid type
   integer, parameter :: num_structured_grids(*) = [3,3,3]
     !! number of subdomains in each coordinate direction
   integer image
@@ -25,7 +27,7 @@ program main
 
     call assert( ni<=num_blocks, "test-problem-discretization-block-structure: enough blocks to distribute to images")
 
-    call block_structured_grid%partition( num_structured_grids, cartesian_grid() )
+    call block_structured_grid%partition( num_structured_grids, prototype )
       !! partition the block-structured grid into subdomains with connectivity implied by the supplied shape array
 
       associate( remainder => mod(num_blocks,ni) )

--- a/src/FD/tests/unit/test-problem-discretization.f90
+++ b/src/FD/tests/unit/test-problem-discretization.f90
@@ -14,6 +14,8 @@ program main
 
   type(problem_discretization) global_grid
     !! encapsulate the global grid structure
+  type(cartesian_grid) prototype
+    !! pass the cartesian_grid type
   integer, parameter :: space_dimensions=3
     !! maximum number of spatial dimensions
   integer, parameter :: lo_bound=1, up_bound=2
@@ -23,7 +25,7 @@ program main
   integer, parameter :: num_structured_grids(*) = [240,5,5]
     !! number of subdomains in each coordinate direction
 
-  call global_grid%partition( num_structured_grids, cartesian_grid() )
+  call global_grid%partition( num_structured_grids, prototype )
     !! partition the block-structured grid into subdomains with connectivity implied by the supplied shape of the 3D array of blocks
 
   associate( my_subdomains => global_grid%my_subdomains() )

--- a/src/FD/tests/unit/test-structured-grid.F90
+++ b/src/FD/tests/unit/test-structured-grid.F90
@@ -23,8 +23,11 @@ program test_structured_grid
   real(r8k) :: x(nx,ny,nz)=1.,y(nx,ny,nz)=0.,z(nx,ny,nz)=-1.
     !! Vector components
   class(structured_grid), allocatable :: coordinate_plane
+    !!
+  type(cartesian_grid) prototype
+    !! pass the cartesian_grid type
 
-  allocate( coordinate_plane, stat=alloc_status, errmsg=alloc_error, mold=cartesian_grid() )
+  allocate( coordinate_plane, stat=alloc_status, errmsg=alloc_error, mold=prototype )
   call assert( alloc_status==success, "test_structured_grid: allocation ("//alloc_error//")" )
 
   call coordinate_plane%set_vector_components(x,y,z)

--- a/src/FD/tests/unit/test-write-problem-discretization.f90
+++ b/src/FD/tests/unit/test-write-problem-discretization.f90
@@ -18,6 +18,8 @@ program main
 
   type(problem_discretization) block_structured_grid
     !! encapsulate the global grid structure
+  type(cartesian_grid) prototype
+    !! pass the cartesian_grid type
   type(json_file) json_problem_description
   integer, parameter :: num_structured_grids(*) = [120,5,5]
     !! number of subdomains in each coordinate direction
@@ -33,7 +35,7 @@ program main
   call assert(num_images()==1,"single-image json file creation")
   call assert(product(num_structured_grids)<=max_block_identifier,"number of blocks is representable")
 
-  call block_structured_grid%partition( num_structured_grids, cartesian_grid() )
+  call block_structured_grid%partition( num_structured_grids, prototype )
     !! partition the block-structured grid into subdomains with connectivity implied by the supplied shape array
 
   call json_problem_description%initialize()  ! specify whatever init options you want.


### PR DESCRIPTION
Fixes to allow `fd` code to build on Windows.

Still working on an error in `morfeus\src\FD\grid\problem_discretization_implementation.F90` at line `223`:
```
error #8212: Omitted field is not initialized. Field initialization missing:   [GRID_INTERFACE^UNITS_]
```
Where:
```Fortran
    call this%partition( plate_3D_geometry%get_block_metadata_shape(), cartesian_grid() )
```