### PR TITLE
Merge fd-dev: fix source allocation bounds in surfaces_implementation.f90

### DIFF
--- a/src/FD/grid/problem_discretization_implementation.F90
+++ b/src/FD/grid/problem_discretization_implementation.F90
@@ -12,7 +12,7 @@ submodule(problem_discretization_interface) define_problem_discretization
   use kind_parameters, only : i4k, r8k
   implicit none
 
-  integer, parameter :: space_dimensions=3, success=0
+  integer, parameter :: success=0
 
 contains
 
@@ -70,8 +70,12 @@ contains
     integer :: b, s, first_point_in_block, first_cell_in_block
     real(r8k), dimension(:,:,:), allocatable :: scalar_fields_values
 
+    if (assertions) call assert(allocated(this%vertices), "problem_discretization%vtk_output: allocated(this%vertices())")
+
     allocate( cell_list(sum( this%vertices%num_cells())) )
-    allocate( points(space_dimensions,0), block_cell_material(0), point_block_id(0) )
+    associate(my_first_block => lbound(this%vertices,1))
+      allocate( points(this%vertices(my_first_block)%space_dimension(),0), block_cell_material(0), point_block_id(0) )
+    end associate
     allocate( vtk_data_(this%num_scalars()) )
     do s = 1, this%num_scalars()
       allocate( vtk_data_(s)%point_scalars(0), vtk_data_(s)%point_div_flux(0) )
@@ -188,7 +192,7 @@ contains
       !! coordinate direction to define
     real(r8k), allocatable :: grid_nodes(:,:,:)
       !! grid node locations and spacing in each coordination direction
-    real(r8k) dx(space_dimensions)
+    real(r8k), allocatable :: dx(:)
     integer alloc_status
     character(len=max_errmsg_len) :: alloc_error
 
@@ -434,6 +438,8 @@ contains
   module procedure set_analytical_scalars
     integer b, f, alloc_status
     character(len=max_errmsg_len) :: alloc_error
+
+    if (assertions) call assert(allocated(this%vertices), "problem_discretization%set_analytical_scalars: allocated(this%vertices)")
 
     if (allocated(this%scalar_fields)) deallocate(this%scalar_fields)
     allocate( this%scalar_fields(lbound(this%vertices,1) : ubound(this%vertices,1), size(scalar_setters)), &

--- a/src/FD/grid/problem_discretization_interface.F90
+++ b/src/FD/grid/problem_discretization_interface.F90
@@ -21,8 +21,6 @@ module problem_discretization_interface
   private
   public :: problem_discretization
 
-  integer, parameter :: space_dimension=3
-
   type, extends(object) :: problem_discretization
     private
     class(structured_grid), allocatable :: block_map
@@ -136,7 +134,7 @@ module problem_discretization_interface
       !! Calculate the 1D block identifer associated with the provided 3D block location
       implicit none
       class(problem_discretization), intent(in) :: this
-      integer, intent(in) :: ijk(space_dimension)
+      integer, intent(in) :: ijk(:)
       integer :: n
     end function
 

--- a/src/FD/grid/surfaces_interface.f90
+++ b/src/FD/grid/surfaces_interface.f90
@@ -52,7 +52,7 @@ module surfaces_interface
 
     pure module function get_halo_data() result(singleton_halo_data)
       !! result contains halo-exchange data packaged in an object array with dimenions
-      !! [my_blocks(first):my_blocks(last), space_dimension, size([forward, backward]))
+      !! `[my_blocks(first):my_blocks(last), space_dimension, size([forward, backward]))]`
       implicit none
       class(package), dimension(:,:,:), allocatable :: singleton_halo_data
     end function

--- a/src/FD/grid/surfaces_interface.f90
+++ b/src/FD/grid/surfaces_interface.f90
@@ -21,7 +21,7 @@ module surfaces_interface
   end enum
 
   integer(enumeration), parameter, dimension(*) :: face_normal = [backward, forward]
-    !! surface outward-normal direction for a given block
+    !! surface outward-normal direction: 'forward' for the direction of increasing coordinate; 'backward' for decreasing
 
   type surfaces
     !! hexahedral structured_grid block surface data: all components will be allocated to have the
@@ -31,14 +31,14 @@ module surfaces_interface
   contains
     procedure, nopass :: is_external_boundary
     procedure, nopass :: set_halo_data
+    procedure, nopass :: get_halo_data
   end type
 
   interface
 
-    module function is_external_boundary(this, block_id, coordinate_direction, face) result(is_external)
+    elemental module function is_external_boundary(block_id, coordinate_direction, face) result(is_external)
       !! result is .true. if the identified structured_grid block surface corresponds to a problem domain boundary
       implicit none
-      class(surfaces), intent(in) :: this
       integer, intent(in) :: block_id, coordinate_direction
       integer(enumeration), intent(in) :: face
       logical is_external
@@ -49,6 +49,13 @@ module surfaces_interface
       implicit none
       class(package), intent(in), dimension(:,:,:) :: my_halo_data
     end subroutine
+
+    pure module function get_halo_data() result(singleton_halo_data)
+      !! result contains halo-exchange data packaged in an object array with dimenions
+      !! [my_blocks(first):my_blocks(last), space_dimension, size([forward, backward]))
+      implicit none
+      class(package), dimension(:,:,:), allocatable :: singleton_halo_data
+    end function
 
   end interface
 


### PR DESCRIPTION
This PR also contains a commit that eliminates all places in FD where a compile-time constant `space_dimension` is used.  This sets up for varying the space dimension to move from the 3D plate to the required 2D cylinder and the 1D sphere.