### PR TITLE
FD: add "::" in type-bound procedure bindings

### DIFF
--- a/src/FD/geometry/block_metadata_interface.F90
+++ b/src/FD/geometry/block_metadata_interface.F90
@@ -37,14 +37,14 @@ module block_metadata_interface
     integer(tag_kind) :: tag_ = untagged
     character(len=max_name_length) :: label_='unlabeled'
   contains
-    procedure set_tag
-    procedure set_label
-    procedure set_subdomain
-    procedure set_max_spacing
-    procedure get_tag
-    procedure get_label
-    procedure get_subdomain
-    procedure get_max_spacing
+    procedure :: set_tag
+    procedure :: set_label
+    procedure :: set_subdomain
+    procedure :: set_max_spacing
+    procedure :: get_tag
+    procedure :: get_label
+    procedure :: get_subdomain
+    procedure :: get_max_spacing
   end type
 
   interface

--- a/src/FD/geometry/geometry_interface.f90
+++ b/src/FD/geometry/geometry_interface.f90
@@ -18,7 +18,7 @@ module geometry_interface
     !! defer case-specific steps to child classes
     private
   contains
-    procedure build
+    procedure :: build
     procedure(set_json_file), deferred :: set_grid_specification
     procedure(set_metadata), deferred :: set_block_metadata
   end type

--- a/src/FD/geometry/plate_3D_interface.F90
+++ b/src/FD/geometry/plate_3D_interface.F90
@@ -25,12 +25,12 @@ module plate_3D_interface
     type(block_metadata), dimension(:,:,:), allocatable :: metadata
     character(len=:), allocatable :: units_system
   contains
-    procedure set_grid_specification
-    procedure set_block_metadata
-    procedure get_block_metadata_shape
-    procedure get_block_domain
-    procedure get_block_metadatum
-    procedure get_block_metadata
+    procedure :: set_grid_specification
+    procedure :: set_block_metadata
+    procedure :: get_block_metadata_shape
+    procedure :: get_block_domain
+    procedure :: get_block_metadatum
+    procedure :: get_block_metadata
   end type
 
   interface


### PR DESCRIPTION
This PR addresses a FORD documentation-generation issue.

Subdirectory affected: src/FD/geometry