### PR TITLE
Cleanup cmake

### DIFF
--- a/src/FV/CMakeLists.txt
+++ b/src/FV/CMakeLists.txt
@@ -80,29 +80,7 @@ option(FAST_USE_EXODUS "Build with Exodus support (broken)" OFF)
 # Make CGNS optional
 option(FAST_USE_CGNS "Build with CGNS support (broken)" OFF)
 
-
-set(SLATEC_srcs
-  src/math/SLATEC/d1mach.f90
-  src/math/SLATEC/dckder.f
-  src/math/SLATEC/denorm.f
-  src/math/SLATEC/dfdjc3.f
-  src/math/SLATEC/dmpar.f
-  src/math/SLATEC/dnls1e.f
-  src/math/SLATEC/dnls1.f
-  src/math/SLATEC/dqrfac.f
-  src/math/SLATEC/dqrslv.f
-  src/math/SLATEC/dwupdt.f
-  src/math/SLATEC/fdump.f
-  src/math/SLATEC/i1mach.f90
-  src/math/SLATEC/j4save.f
-  src/math/SLATEC/xercnt.f
-  src/math/SLATEC/xerhlt.f
-  src/math/SLATEC/xermsg.f
-  src/math/SLATEC/xerprn.f
-  src/math/SLATEC/xersve.f
-  src/math/SLATEC/xgetua.f
-  src/math/SLATEC/xsetf.f
-  )
+# Set source files
 set(morfeus_fv_srcs
   src/basics/class_connectivity.f90
   src/basics/class_connectivity_procedures.f90

--- a/src/FV/CMakeLists.txt
+++ b/src/FV/CMakeLists.txt
@@ -75,10 +75,10 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src/mesh_optimize/OptMS")
 
 
 # Add option for enabling exodus
-option(FAST_USE_EXODUS "Build with Exodus support (broken)" OFF)
+option(USE_EXODUS "Build with Exodus support (broken)" OFF)
 
 # Make CGNS optional
-option(FAST_USE_CGNS "Build with CGNS support (broken)" OFF)
+option(USE_CGNS "Build with CGNS support (broken)" OFF)
 
 # Set source files
 set(morfeus_fv_srcs
@@ -188,8 +188,6 @@ set(morfeus_fv_srcs
   src/mesh/part_graph_procedures.f90
   src/mesh/part_random.f90
   src/mesh/part_random_procedures.f90
-  src/mesh/rd_cgns_mesh.F90
-#  src/mesh/rd_exodus_mesh.f90 # Commented out b/c functionality does not yet work
   src/mesh/rd_gambit_implementation.f90
   src/mesh/rd_inp_mesh_implementation.f90
   src/mesh/renum.F90
@@ -289,11 +287,15 @@ set(morfeus_fv_C_srcs
   src/mesh_optimize/right_handed.c
   )
 
-if(FAST_USE_EXODUS)
+if(USE_EXODUS)
   list(APPEND morfeus_fv_srcs
     src/mesh/rd_exodus_mesh.f90)
 endif()
 
+if(USE_CGNS)
+  list(APPEND morfeus_fv_srcs
+  src/mesh/rd_cgns_mesh.F90)
+endif()
 #----------------------
 # Find pre-req packages
 #----------------------
@@ -461,7 +463,7 @@ endforeach()
 include_directories(${PSBLAS_Fortran_INCLUDE_DIR})
 include_directories(${METIS_INCLUDES})
 
-if(${FAST_USE_CGNS})
+if(${USE_CGNS})
   find_morfeus_fv_prereq( METIS REQUIRED )
   include_directories(${CGNS_INCLUDES})
   add_definitions(-DHAVE_CGNS)
@@ -489,7 +491,7 @@ if(${FAST_USE_CGNS})
   endif()
 endif()
 
-if(FAST_USE_EXODUS)
+if(USE_EXODUS)
   # NetCDF will be pulled in through SEACASExodus transitive target properties
   find_morfeus_fv_prereq(SEACASExodus_for
     REQUIRED
@@ -540,7 +542,7 @@ if(TARGET jsonfortran-static)
     PUBLIC jsonfortran-static)
 endif()
 
-if(${FAST_USE_CGNS})
+if(${USE_CGNS})
   target_link_libraries(morfeus_fv
     PUBLIC ${CGNS_LIBRARIES})
 endif()
@@ -551,7 +553,7 @@ target_link_libraries(morfeus_fv
   PUBLIC ${LAPACK_LIBRARIES}
   PUBLIC ${BLAS_LIBRARIES}
   )
-if(FAST_USE_EXODUS)
+if(USE_EXODUS)
   target_link_libraries(morfeus_fv
     PUBLIC ${SEACASExodus_for_LIBRARIES})
 endif()
@@ -730,7 +732,7 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/applications")
     applications/fast_heat/cases/test_unsteady/fast.json
     ${integ_test_dir}/unsteady_heat_pipe)
 
-  if(${FAST_USE_CGNS})
+  if(${USE_CGNS})
     # Steady piston conduction test
     # Should produce:
     #   a_sparse.mtx b_rhs.mtx out_nemo.vtk time.dat

--- a/src/FV/src/basics/class_connectivity_procedures.f90
+++ b/src/FV/src/basics/class_connectivity_procedures.f90
@@ -737,7 +737,7 @@ CONTAINS
                 nel_ = nglob
             CASE('l')
                 nel_ = nloc
-            CASE default
+            CASE DEFAULT
                 WRITE(*,100)
                 CALL abort_psblas
             END SELECT
@@ -765,7 +765,7 @@ CONTAINS
                 nconn_ = nglob
             CASE('l')
                 nconn_ = nloc
-            CASE default
+            CASE DEFAULT
                 WRITE(*,100)
                 CALL abort_psblas
             END SELECT

--- a/src/FV/src/bc/class_bc_math_procedures.f90
+++ b/src/FV/src/bc/class_bc_math_procedures.f90
@@ -125,7 +125,7 @@ CONTAINS
             na = 1; nb = 1; nc = nbf
         CASE(  bc_robin_map_)
             na = nbf; nb = nbf; nc = nbf
-        CASE default
+        CASE DEFAULT
             WRITE(*,200)
             CALL abort_psblas
         END SELECT
@@ -239,7 +239,7 @@ CONTAINS
                 b(IF) = bc%b(IF)
                 c(IF) = bc%c(IF)
             END DO
-        CASE default
+        CASE DEFAULT
             WRITE(*,200)
             CALL abort_psblas
         END SELECT
@@ -293,7 +293,7 @@ CONTAINS
                 b(IF) = bc(1)%b(1)
                 c(IF) = vector_(bc(1)%c(IF),bc(2)%c(IF),bc(3)%c(IF))
             END DO
-        CASE default
+        CASE DEFAULT
             WRITE(*,300)
             CALL abort_psblas
         END SELECT
@@ -332,7 +332,7 @@ CONTAINS
             bc%a(i) = a
             bc%b(i) = b
             bc%c(i) = c
-        CASE default
+        CASE DEFAULT
             WRITE(*,100)
             CALL abort_psblas
         END SELECT
@@ -437,7 +437,7 @@ CONTAINS
 
                 bx(ibf) = (b(i) * x(im) + c(i) * d) / r
             END DO
-        CASE default
+        CASE DEFAULT
             WRITE(*,100)
             CALL abort_psblas
         END SELECT
@@ -504,7 +504,7 @@ CONTAINS
                 ibf = ib_offset + i
                 bx(ibf) = x(im) + d * c(1)
             END DO
-        CASE default
+        CASE DEFAULT
             WRITE(*,100)
             CALL abort_psblas
         END SELECT
@@ -539,7 +539,7 @@ CONTAINS
             bc_type = 'Homogeneous Neumann'
         CASE(bc_robin_, bc_robin_convection_)
             bc_type = 'Homogeneous Robin'
-        CASE default
+        CASE DEFAULT
             bc_type = 'Unknown '
             WRITE(0,*) bc_type, ' ',bc%id, 'Bailing out'
             RETURN

--- a/src/FV/src/bc/class_bc_procedures.f90
+++ b/src/FV/src/bc/class_bc_procedures.f90
@@ -120,7 +120,7 @@ CONTAINS
                 CALL create_bc_math(bc(ib)%math,input_file,bc_sec,nbf)
             CASE(bc_wall_)
                 CALL create_bc_wall(bc(ib)%wall,input_file,bc_sec,nbf)
-            CASE default
+            CASE DEFAULT
                 WRITE(*,400)
                 CALL abort_psblas
             END SELECT
@@ -248,7 +248,7 @@ CONTAINS
             CALL bc%math%set_bc_math_map(i,a,b,c)
         CASE(bc_wall_)
             CALL bc%wall%set_bc_wall_map(i,a,b,c)
-        CASE default
+        CASE DEFAULT
             WRITE(*,100)
             CALL abort_psblas
         END SELECT
@@ -266,7 +266,7 @@ CONTAINS
         SELECT CASE(bc%id)
         CASE(bc_wall_)
             CALL bc%wall%set_bc_wall_map(i,a,b,c)
-        CASE default
+        CASE DEFAULT
             WRITE(*,100)
             CALL abort_psblas
         END SELECT
@@ -291,7 +291,7 @@ CONTAINS
             CALL update_boundary_math(ib,bc%math,msh,x,bx)
         CASE(bc_wall_)
             CALL update_boundary_wall(ib,bc%wall,dim,msh,mats,im,x,bx)
-        CASE default
+        CASE DEFAULT
             WRITE(*,100)
             CALL abort_psblas
         END SELECT
@@ -312,7 +312,7 @@ CONTAINS
         SELECT CASE(bc%id)
         CASE(bc_wall_)
             CALL update_boundary_wall(ib,bc%wall,dim,msh,x,bx)
-        CASE default
+        CASE DEFAULT
             WRITE(*,100)
             CALL abort_psblas
         END SELECT

--- a/src/FV/src/bc/class_bc_wall_procedures.f90
+++ b/src/FV/src/bc/class_bc_wall_procedures.f90
@@ -175,7 +175,7 @@ CONTAINS
         SELECT CASE(bc%id(1))
         CASE(bc_temp_convection_map_)
             CALL bc%temp%set_bc_math_map(i,a,b,c)
-        CASE default
+        CASE DEFAULT
             WRITE(*,100)
             CALL abort_psblas
         END SELECT
@@ -195,7 +195,7 @@ CONTAINS
             CALL bc%vel(1)%set_bc_math_map(i,a,b,c%x_())
             CALL bc%vel(2)%set_bc_math_map(i,a,b,c%y_())
             CALL bc%vel(3)%set_bc_math_map(i,a,b,c%x_())
-        CASE default
+        CASE DEFAULT
             WRITE(*,100)
             CALL abort_psblas
         END SELECT
@@ -377,7 +377,7 @@ SUBROUTINE rd_inp_bc_wall(input_file,sec,nbf,id,bc_temp,bc_conc,bc_vel,bc_stress
             CASE(bc_temp_convection_map_) ! Convection map
                 !READ(inp,'()')         ! To be actually set at the first mapping
 
-            CASE default
+            CASE DEFAULT
                 WRITE(*,210)
                 CALL abort_psblas
             END SELECT
@@ -397,7 +397,7 @@ SUBROUTINE rd_inp_bc_wall(input_file,sec,nbf,id,bc_temp,bc_conc,bc_vel,bc_stress
             CASE(bc_conc_adiabatic_)  ! Adiabatic wall
                 !READ(inp,'()')
 
-            CASE default
+            CASE DEFAULT
                 WRITE(*,210)
                 CALL abort_psblas
             END SELECT
@@ -420,7 +420,7 @@ SUBROUTINE rd_inp_bc_wall(input_file,sec,nbf,id,bc_temp,bc_conc,bc_vel,bc_stress
                 WRITE(0,*) 'rd_inp_bc_wall: Debug: work', work(1:3,bc_vel_)
             CASE(bc_vel_moving_)
                 !READ(inp,'()')
-            CASE default
+            CASE DEFAULT
                 WRITE(*,220)
                 CALL abort_psblas
             END SELECT
@@ -442,7 +442,7 @@ SUBROUTINE rd_inp_bc_wall(input_file,sec,nbf,id,bc_temp,bc_conc,bc_vel,bc_stress
                 CALL nemo_json%get(trim(sec)//'.stress.v2', work(2,bc_stress_), found)
                 CALL nemo_json%get(trim(sec)//'.stress.v3', work(3,bc_stress_), found)
                 WRITE(0,*) 'rd_inp_bc_wall: Debug: work', work(1:3,bc_stress_)
-            CASE default
+            CASE DEFAULT
                 WRITE(*,230)
                 CALL abort_psblas
             END SELECT
@@ -521,7 +521,7 @@ SUBROUTINE rd_inp_bc_wall(input_file,sec,nbf,id,bc_temp,bc_conc,bc_vel,bc_stress
         CALL bc_vel(3)%alloc_bc_math(bc_dirichlet_map_,nbf,&
             & a=(/1.d0/),b=(/0.d0/),c=(/(0.d0, inp=1,nbf)/))
     CASE(-1)
-    CASE default
+    CASE DEFAULT
         WRITE(0,*) 'Fix here unimplemented BC setup !!'
 
     END SELECT
@@ -544,7 +544,7 @@ SUBROUTINE rd_inp_bc_wall(input_file,sec,nbf,id,bc_temp,bc_conc,bc_vel,bc_stress
         CALL bc_stress(3)%alloc_bc_math(bc_dirichlet_,nbf,&
             & a=(/1.d0/),b=(/0.d0/),c=(/work(3,bc_stress_)/))
 
-    CASE default
+    CASE DEFAULT
         WRITE(0,*) 'Fix here unimplemented BC setup !!', id(bc_stress_)
 
     END SELECT

--- a/src/FV/src/bc/rd_inp_bc.f90
+++ b/src/FV/src/bc/rd_inp_bc.f90
@@ -116,7 +116,7 @@ SUBMODULE(tools_bc) rd_inp_bc_implementation
                     id(ib) = bc_math_
                 CASE('wall')
                     id(ib) = bc_wall_
-                CASE default
+                CASE DEFAULT
                     WRITE(*,200)
                     CALL abort_psblas
                 END SELECT

--- a/src/FV/src/bc/rd_inp_bc_math.f90
+++ b/src/FV/src/bc/rd_inp_bc_math.f90
@@ -93,7 +93,7 @@ SUBMODULE(tools_bc) rd_inp_bc_math_implementation
                 READ(inp,*) par, abc(3)
             CASE(bc_robin_)
                 READ(inp,*) par, abc(1), abc(2), abc(3)
-            CASE default
+            CASE DEFAULT
                 abc(:) = 0.d0
             END SELECT
 
@@ -117,7 +117,7 @@ SUBMODULE(tools_bc) rd_inp_bc_math_implementation
             na = 1; nb = 1; nc = nbf
         CASE(  bc_robin_map_)
             na = nbf; nb = nbf; nc = nbf
-        CASE default
+        CASE DEFAULT
             WRITE(*,100)
             CALL abort_psblas
         END SELECT
@@ -145,7 +145,7 @@ SUBMODULE(tools_bc) rd_inp_bc_math_implementation
             a(:) = 0.d0 ! To be actually set at the first mapping
             b(:) = 0.d0 ! To be actually set at the first mapping
             c(:) = 0.d0 ! To be actually set at the first mapping
-        CASE default
+        CASE DEFAULT
             WRITE(*,100)
             CALL abort_psblas
         END SELECT

--- a/src/FV/src/field/class_discretization_procedures.f90
+++ b/src/FV/src/field/class_discretization_procedures.f90
@@ -97,7 +97,7 @@ CONTAINS
                         r%blend = 1.d0
 !!$             case(id_tvd_) ! Any scheme requiring a blending factor too
 !!$                read(inp,*) r%blend
-                    CASE default
+                    CASE DEFAULT
                         WRITE(*,200)
                         CALL abort_psblas
                     END SELECT

--- a/src/FV/src/material/class_material.f90
+++ b/src/FV/src/material/class_material.f90
@@ -131,12 +131,12 @@ MODULE class_material
             REAL(psb_dpk_), INTENT(OUT) :: f
         END SUBROUTINE matlaw_s
 
-        MODULE SUBROUTINE matlaw_fast_s(mat, t, property, f)
+        MODULE SUBROUTINE matlaw_matlib_s(mat, t, property, f)
             CLASS(material), INTENT(IN) :: mat
             REAL(psb_dpk_), INTENT(IN) :: t
             REAL(psb_dpk_), INTENT(OUT) :: f
             CHARACTER(LEN=*), INTENT(IN) :: property
-        END SUBROUTINE matlaw_fast_s
+        END SUBROUTINE matlaw_matlib_s
 
     END INTERFACE matlaw
 

--- a/src/FV/src/material/class_material_procedures.f90
+++ b/src/FV/src/material/class_material_procedures.f90
@@ -167,33 +167,33 @@ CONTAINS
             IF(dim == density_)       THEN
                 DO i = 1, SIZE(im)
                     IF (mats(im(i))%mat%mat_id_() < 400) THEN
-                        CALL matlaw_fast_s(mats(im(i))%mat,t(i),'ASFABDENSITY',f(i))
+                        CALL matlaw_matlib_s(mats(im(i))%mat,t(i),'ASFABDENSITY',f(i))
                     ELSE
-                        CALL matlaw_fast_s(mats(im(i))%mat,t(i),'DENSITY',f(i))
+                        CALL matlaw_matlib_s(mats(im(i))%mat,t(i),'DENSITY',f(i))
                     END IF
                 END DO
             ELSEIF(dim == conductivity_)  THEN
                 DO i = 1, SIZE(im)
-                    CALL matlaw_fast_s(mats(im(i))%mat,t(i),'THERMCOND',f(i))
+                    CALL matlaw_matlib_s(mats(im(i))%mat,t(i),'THERMCOND',f(i))
                 END DO
             ELSEIF(dim == surface_/time_)  THEN
                 DO i = 1, SIZE(im)
-                    CALL matlaw_fast_s(mats(im(i))%mat,t(i),'THERMCOND',f(i))
+                    CALL matlaw_matlib_s(mats(im(i))%mat,t(i),'THERMCOND',f(i))
                 END DO
             ELSEIF(dim == specific_heat_) THEN
                 DO i = 1, SIZE(im)
-                    CALL matlaw_fast_s(mats(im(i))%mat,t(i),'SPECHEAT',f(i))
+                    CALL matlaw_matlib_s(mats(im(i))%mat,t(i),'SPECHEAT',f(i))
                 END DO
             ELSEIF(dim == youngs_modulus_) THEN
                 DO i = 1, SIZE(im)
-                    CALL matlaw_fast_s(mats(im(i))%mat,t(i),'YOUNG_MOD',f(i))
+                    CALL matlaw_matlib_s(mats(im(i))%mat,t(i),'YOUNG_MOD',f(i))
                 END DO
             ELSEIF(dim == therm_exp_coeff_) THEN
                 DO i = 1, SIZE(im)
                     IF (mats(im(i))%mat%mat_id_() < 400) THEN
-                        CALL matlaw_fast_s(mats(im(i))%mat,t(i),'THEXP_COEF',f(i))
+                        CALL matlaw_matlib_s(mats(im(i))%mat,t(i),'THEXP_COEF',f(i))
                     ELSE
-                        CALL matlaw_fast_s(mats(im(i))%mat,t(i),'THEXP',f(i))
+                        CALL matlaw_matlib_s(mats(im(i))%mat,t(i),'THEXP',f(i))
                     END IF
                 END DO
             ELSE
@@ -228,11 +228,11 @@ CONTAINS
     END PROCEDURE matlaw_s
 
 
-    MODULE PROCEDURE matlaw_fast_s
+    MODULE PROCEDURE matlaw_matlib_s
 
         f = MatProp(Mat_id=mat%mat_id, Property=property, Temperature=t)
 
-    END PROCEDURE matlaw_fast_s
+    END PROCEDURE matlaw_matlib_s
 
     ! ----- Check Procedures -----
 

--- a/src/FV/src/material/load_material.f90
+++ b/src/FV/src/material/load_material.f90
@@ -60,7 +60,7 @@ SUBMODULE(tools_material) load_material_implementation
                 CALL load_copper(state,dtemp,tmin,tmax,rho,lambda,sh)
             CASE('water')
                 CALL load_water(state,dtemp,tmin,tmax,rho,mu,lambda,sh)
-            CASE default
+            CASE DEFAULT
                 WRITE(*,100)
             END SELECT
 

--- a/src/FV/src/math/class_iterating_procedures.f90
+++ b/src/FV/src/math/class_iterating_procedures.f90
@@ -90,7 +90,7 @@ CONTAINS
         CASE(it_counter_)
             iter%delta = 0.d0
             iter%tol   = 0.d0
-        CASE default
+        CASE DEFAULT
             WRITE(*,100)
             CALL abort_psblas
         END SELECT

--- a/src/FV/src/math/lu_implementation.F90
+++ b/src/FV/src/math/lu_implementation.F90
@@ -108,7 +108,7 @@ contains
     CASE(2)
         CALL lu_fact_2(a,ipiv,info)
 
-    CASE default
+    CASE DEFAULT
 
         info = 0
         DO j = 1, n

--- a/src/FV/src/math/psb_build_prec.f90
+++ b/src/FV/src/math/psb_build_prec.f90
@@ -120,7 +120,7 @@
     !!$    call prec%init('ml',info,nlev=3)
     !!$    call prec%set(coarse_solve_,umf_,info)
     !!$    call prec%set(coarse_sweeps_,4,info)
-        CASE default
+        CASE DEFAULT
             WRITE(*,100)
             CALL abort_psblas
         END SELECT
@@ -132,7 +132,7 @@
             SELECT CASE(psb_toupper(TRIM(cprec)))
             CASE ('NOPREC','DIAG','BJAC','2LI4S','2LU4S','3LI4S','3LU4S')
                 ! Things are OK
-            CASE default
+            CASE DEFAULT
                 WRITE(*,200)
                 CALL abort_psblas
             END SELECT

--- a/src/FV/src/mesh/class_mesh_procedures.F90
+++ b/src/FV/src/mesh/class_mesh_procedures.F90
@@ -222,7 +222,7 @@ CONTAINS
                     & msh%verts, msh%faces, msh%cells, &
                     & msh%v2f, msh%v2c, msh%f2c, msh%c2g)
 #else
-                error STOP "FAST/MORFEUS built without CNGS support! Unable to continue."
+                error STOP "MORFEUS built without CNGS support! Unable to continue."
 #endif
             CASE('e')
 #ifdef HAVE_EXODUS
@@ -230,7 +230,7 @@ CONTAINS
                     & msh%verts, msh%faces, msh%cells, &
                     & msh%v2f, msh%v2c, msh%f2c, msh%c2g)
 #else
-                error STOP "FAST/MORFEUS built without exodus support! Unable to continue."
+                error STOP "MORFEUS built without exodus support! Unable to continue."
 #endif
             CASE('neu')
                 CALL rd_gambit_mesh(mesh_file, msh%id, msh%nbc, msh%ncd, &

--- a/src/FV/src/mesh/class_mesh_procedures.F90
+++ b/src/FV/src/mesh/class_mesh_procedures.F90
@@ -222,7 +222,7 @@ CONTAINS
                     & msh%verts, msh%faces, msh%cells, &
                     & msh%v2f, msh%v2c, msh%f2c, msh%c2g)
 #else
-                error STOP "MORFEUS built without CNGS support! Unable to continue."
+                ERROR STOP "MORFEUS built without CNGS support! Unable to continue."
 #endif
             CASE('e')
 #ifdef HAVE_EXODUS
@@ -230,13 +230,13 @@ CONTAINS
                     & msh%verts, msh%faces, msh%cells, &
                     & msh%v2f, msh%v2c, msh%f2c, msh%c2g)
 #else
-                error STOP "MORFEUS built without exodus support! Unable to continue."
+                ERROR STOP "MORFEUS built without exodus support! Unable to continue."
 #endif
             CASE('neu')
                 CALL rd_gambit_mesh(mesh_file, msh%id, msh%nbc, msh%ncd, &
                     & msh%verts, msh%faces, msh%cells, &
                     & msh%v2f, msh%v2c, msh%f2c, msh%c2g)
-            CASE default
+            CASE DEFAULT
                 WRITE(*,200)
                 CALL abort_psblas
             END SELECT

--- a/src/FV/src/mesh/cmp_mesh_implementation.f90
+++ b/src/FV/src/mesh/cmp_mesh_implementation.f90
@@ -350,7 +350,7 @@ SUBMODULE (tools_mesh) cmp_mesh_implementation
                 ! METIS Partitioning
                 CALL bld_part_graph(xadj_glob,adjncy_glob,ipart=1)
                 CALL get_part_graph(part_cells)
-            CASE default
+            CASE DEFAULT
                 WRITE(*,200)
                 CALL abort_psblas
             END SELECT
@@ -416,7 +416,7 @@ SUBMODULE (tools_mesh) cmp_mesh_implementation
                 ! Deallocates private storage of renum module
                 CALL stop_renum
             ENDIF
-        CASE default
+        CASE DEFAULT
             WRITE(*,100)
             CALL abort_psblas
         END SELECT

--- a/src/FV/src/mesh/rd_cgns_mesh.F90
+++ b/src/FV/src/mesh/rd_cgns_mesh.F90
@@ -49,7 +49,6 @@ SUBMODULE (tools_mesh) rd_cgns_mesh_implementation
 
         MODULE PROCEDURE rd_cgns_mesh
     !! @note Compatible only with CGNS v3.3.0 and above. Earlier versions are not supported.
-#ifdef FAST_USE_CGNS
     !! Note: CGNS functionality is not working for FAST. Currently set to pre-process entire module procedure
     !!       so that the implementation exists but is empty. IP - 6/6/2019
     USE cgns, ONLY &
@@ -1151,7 +1150,7 @@ SUBMODULE (tools_mesh) rd_cgns_mesh_implementation
     WRITE(*,'()')
 
 100 FORMAT(' ERROR! Memory allocation failure in RD_CGNS_MESH')
-#endif
+
         END PROCEDURE rd_cgns_mesh
 
 END SUBMODULE rd_cgns_mesh_implementation

--- a/src/FV/src/mesh/rd_cgns_mesh.F90
+++ b/src/FV/src/mesh/rd_cgns_mesh.F90
@@ -49,7 +49,7 @@ SUBMODULE (tools_mesh) rd_cgns_mesh_implementation
 
         MODULE PROCEDURE rd_cgns_mesh
         !! @note Compatible only with CGNS v3.3.0 and above. Earlier versions are not supported.
-        !! Note: CGNS functionality is not working for FAST. Currently set to pre-process entire module procedure
+        !! Note: CGNS functionality is not working for Morfeus. Currently set to pre-process entire module procedure
         !!       so that the implementation exists but is empty. IP - 6/6/2019
         USE cgns, ONLY : cg_vertex       => vertex, & ! avoids "vertex" name conflict with class_vertex.f90
             & CG_Unstructured => Unstructured, &

--- a/src/FV/src/mesh/rd_cgns_mesh.F90
+++ b/src/FV/src/mesh/rd_cgns_mesh.F90
@@ -48,1108 +48,1106 @@ SUBMODULE (tools_mesh) rd_cgns_mesh_implementation
     CONTAINS
 
         MODULE PROCEDURE rd_cgns_mesh
-    !! @note Compatible only with CGNS v3.3.0 and above. Earlier versions are not supported.
-    !! Note: CGNS functionality is not working for FAST. Currently set to pre-process entire module procedure
-    !!       so that the implementation exists but is empty. IP - 6/6/2019
-    USE cgns, ONLY &
-        : cg_vertex       => vertex & ! avoids "vertex" name conflict with class_vertex.f90
-        , CG_Unstructured => Unstructured &
-        , CG_BAR_2        => BAR_2 &
-        , CG_TRI_3        => TRI_3 &
-        , CG_QUAD_4       => QUAD_4 &
-        , CG_TETRA_4      => TETRA_4 &
-        , CG_PYRA_5       => PYRA_5 &
-        , CG_PENTA_6      => PENTA_6 &
-        , CG_HEXA_8       => HEXA_8 &
-        , CG_MODE_READ &
-        , cgenum_t &
-        , cgsize_t &
-        , CG_OK &
-        , cg_nbases_f &
-        , cg_nzones_f &
-        , cg_nbocos_f &
-        , cg_error_exit_f &
-        , cg_nsections_f &
-        , cg_close_f
-    !
-    USE class_psblas
-    USE class_cell
-    USE class_connectivity
-    USE class_face
-    USE class_vertex
-    USE tools_math
-    USE type_table, ONLY : table, alloc_table, free_table, get_dual_table
-    IMPLICIT NONE
-    !
-    INTEGER, PARAMETER :: nlen = 80
-    !
-    ! --- Local variables ---
-    !
-    ! Parameters
-    LOGICAL, PARAMETER :: debug = .FALSE.
-    INTEGER, PARAMETER :: mesh = 10
-    INTEGER, PARAMETER :: MAX_LEN = 32
-    !
-    ! CGNS variables
-    INTEGER :: index_file, index_base, index_zone, index_sect, ier
-    INTEGER :: cell_dim, phys_dim, nbocos, nsections
-    INTEGER :: itype, istart, iend, nbndry, iparent_flag, iparentdata
-    INTEGER :: bocotype, ptset_type
-    INTEGER :: NormalIndex, NormalListFlag, NormalDataType, NormalList, ndataset
-    INTEGER :: isect_cell, isect_bc
-    CHARACTER(len=32) :: basename, zonename, sectionname
-    INTEGER(cgenum_t) :: type_coordinate_data
-    INTEGER(cgsize_t) :: isize(3)
-    CHARACTER(len=MAX_LEN) :: name_coordinate
-    INTEGER :: type_file
-    !
-    ! Local copies of V2F_, V2C_, F2C_ objects (connectivity class)
-    TYPE(table) :: v2f, v2c, f2c
-    !
-    ! Vertex-related variables
-    INTEGER :: nverts
-    INTEGER(cgsize_t) :: vertsmax !! number of vertices
-    INTEGER(cgsize_t) :: vertsmin=1
-    LOGICAL, ALLOCATABLE :: on_boundary(:)
-    REAL(psb_dpk_), ALLOCATABLE :: xv(:), yv(:), zv(:)
-    !
-    ! Face-related variables
-    INTEGER :: nfaces
-    INTEGER, ALLOCATABLE :: fnv(:), imaster(:), islave(:), iflag(:)
-    INTEGER, ALLOCATABLE :: facenv(:), facemaster(:), faceslave(:), faceflag(:)
-    !
-    ! Cell-related variables
-    INTEGER :: ncells
-    INTEGER, ALLOCATABLE :: cellnv(:), cellnf(:), cellgroup(:)
-    CHARACTER(len=3), ALLOCATABLE :: cellgeo(:)
-    !
-    ! Group-related variables
-    INTEGER :: ngroups
-    INTEGER, ALLOCATABLE :: groupnc(:), groupmat(:)
-    CHARACTER(len=32), ALLOCATABLE :: groupname(:)
-    TYPE(table) :: c2g
-    !
-    ! BC-related variables
-    INTEGER :: nbcfaces
-    INTEGER, ALLOCATABLE :: bcnf(:)
-    INTEGER(cgsize_t), ALLOCATABLE :: bcnf_cg(:)
-    CHARACTER(len=32), ALLOCATABLE :: bcname(:)
-    TYPE(table) :: f2b, bcface
-    !
-    ! Work variables
-    LOGICAL :: found
-    INTEGER :: i, i1, i2, info, j, j1, j2, k,k1, k2, l, m, n
-    INTEGER :: ib, ic, ig
-    INTEGER :: IF, if1, if2
-    INTEGER :: iv, iv1, iv2, iv3, iv4, iv5, iv6, iv7, iv8
-    INTEGER, ALLOCATABLE :: perm(:), pinv(:)
-    INTEGER, ALLOCATABLE :: aux(:,:), buf(:), work1(:), work2(:)
-    INTEGER(cgsize_t), ALLOCATABLE :: work1_cg(:), f2btab_cg(:), bcfacetab_cg(:)
-    TYPE(table) :: dmy, f2v
-
-    ! ------------------------------------------------------------------
-
-    WRITE(*,*) 'Importing mesh in .CGNS format on P0'
-
-    ! Check file type
-    CALL cg_is_cgns_f(TRIM(ADJUSTL(mesh_file)),type_file,ier)
-    IF(ier /= CG_OK) THEN
-        WRITE (*,*) 'ERROR! Unsupported file format'
-        CALL abort_psblas
-    END IF
-
-    ! Opens file *.cgns
-    CALL cg_open_f(TRIM(ADJUSTL(mesh_file)),CG_MODE_READ,index_file,ier)
-    IF(ier /= CG_OK) CALL cg_error_exit_f
-
-    ! Finds number of bases and zones
-    ! NOTE: Only one base and one zone per base are assumed respectively
-    CALL cg_nbases_f(index_file,index_base,ier)
-    IF(ier /= CG_OK) CALL cg_error_exit_f
-
-    IF (index_base /= 1) THEN
-        WRITE (*,*) 'ERROR! Unsupported number of CGNS bases'
-        CALL abort_psblas
-    END IF
-    CALL cg_nzones_f(index_file,index_base,index_zone,ier)
-    IF (index_zone /= 1) THEN
-        WRITE (*,*) 'ERROR! Unsupported number of CGNS zones'
-        CALL abort_psblas
-    END IF
-
-    ! mesh ID and global parameters
-    CALL cg_base_read_f(index_file,index_base,basename,cell_dim,phys_dim,ier)
-    IF(ier /= CG_OK) CALL cg_error_exit_f
-    CALL cg_zone_read_f(index_file,index_base,index_zone,zonename,isize,ier)
-    IF(ier /= CG_OK) CALL cg_error_exit_f
-    CALL cg_nbocos_f(index_file,index_base,index_zone,nbocos,ier)
-    IF(ier /= CG_OK) CALL cg_error_exit_f
-    mesh_id = zonename
-    nverts = isize(1)
-    ncells = isize(2)
-    vertsmax = nverts
-
-    ! By default isize(3) is equal to 0
-    ngroups = 1 ! TO DO: how to manage multiple groups?
-    nbc = nbocos
-    ncd = cell_dim
-    IF(ncd /= 2.AND.ncd /= 3) THEN
-        WRITE(*,*) 'ERROR! NCD in CGNS file must be 2 or 3'
-        CALL abort_psblas
-    END IF
-
-    ! #############################################################################
-    IF(debug) THEN
-        WRITE(*,*)
-        WRITE(*,300) TRIM(mesh_id), nverts, ncells, ngroups, nbc, ncd
-        WRITE(*,*)
-300     FORMAT(' meshid: ',a,' nverts: ',i6,' ncells: ',i6,' ngroups ',i2,&
-            & ' nbc: ',i2,' ncd: ',i2)
-    END IF
-    ! #############################################################################
-
-    ALLOCATE (xv(nverts), yv(nverts), zv(nverts), &
-        & cellnv(ncells), cellnf(ncells), cellgeo(ncells), cellgroup(ncells), &
-        & stat=info)
-    IF(info /= 0) THEN
-        WRITE (*,100)
-        CALL abort_psblas
-    END IF
-
-    ! Check coordinate data type
-    CALL cg_coord_info_f(index_file, index_base, index_zone, 1, type_coordinate_data, name_coordinate, ier)
-    IF(ier /= CG_OK) CALL cg_error_exit_f()
-
-    ! Reads vertices coordinates
-    CALL cg_coord_read_f(index_file,index_base,index_zone,'CoordinateX',&
-        &  type_coordinate_data,vertsmin,vertsmax,xv,ier)
-    IF(ier /= CG_OK) CALL cg_error_exit_f
-    CALL cg_coord_read_f(index_file,index_base,index_zone,'CoordinateY',&
-        & type_coordinate_data,vertsmin,vertsmax,yv,ier)
-    IF(ier /= CG_OK) CALL cg_error_exit_f
-    CALL cg_coord_read_f(index_file,index_base,index_zone,'CoordinateZ',&
-        & type_coordinate_data,vertsmin,vertsmax,zv,ier)
-    IF(ier /= CG_OK) CALL cg_error_exit_f
-
-    ! #############################################################################
-    IF(debug) THEN
-        DO iv = 1, nverts
-            WRITE(*,310) iv, xv(iv), yv(iv), zv(iv)
-        END DO
-        WRITE(*,*)
-310     FORMAT(' vertex: ',i5,' | ','coordinates: ',3(1x,d13.6))
-    END IF
-    ! #############################################################################
-
-    ! Finds number of sections in CGNS file
-    CALL cg_nsections_f(index_file,index_base,index_zone,nsections,ier)
-    IF(ier /= CG_OK) CALL cg_error_exit_f
-
-    ! k = number of sections containing cell elements
-    DO index_sect = 1, nsections
-        CALL cg_section_read_f(index_file,index_base,index_zone,index_sect,&
-            & sectionname,itype,istart,iend,nbndry,iparent_flag,ier)
-        IF(ier /= CG_OK) CALL cg_error_exit_f
-        IF (iend == ncells) THEN
-            isect_cell = index_sect
-            EXIT
-        END IF
-    END DO
-    isect_bc=nsections
-
-    ! Reads sections containing vertex-to-cell connectivities
-    IF(ncd == 2) THEN
-        n = 4 * ncells
-    ELSE IF(ncd == 3) THEN
-        n = 8 * ncells
-    END IF
-    ALLOCATE(work1(n),stat=info)
-    IF(info /= 0) THEN
-        WRITE(*,100)
-        CALL abort_psblas
-    END IF
-
-    ALLOCATE(work1_cg(n),stat=info)
-    IF(info /= 0) THEN
-        WRITE(*,100)
-        CALL abort_psblas
-    END IF
-
-    CALL v2c%alloc_table(nel=ncells)
-
-    work1 = 0
-    work1_cg = 0
-    i1 = 1; i2 = 0; v2c%lookup(i1) = 1
-    DO index_sect = 1, isect_cell
-        CALL cg_section_read_f(index_file,index_base,index_zone,index_sect,&
-            & sectionname,itype,istart,iend,nbndry,iparent_flag,ier)
-        IF(ier /= CG_OK) CALL cg_error_exit_f
-        DO ic = istart, iend
-            SELECT CASE(itype)
-            CASE(5)
-                cellnv(ic) = 3
-                cellnf(ic) = 3
-                cellgroup(ic) = -1
-                cellgeo(ic) ='tri'
-            CASE(7)
-                cellnv(ic) = 4
-                cellnf(ic) = 4
-                cellgroup(ic) = -1
-                cellgeo(ic) = 'qua'
-            CASE(10)
-                cellnv(ic) = 4
-                cellnf(ic) = 4
-                cellgroup(ic) = -1
-                cellgeo(ic) = 'tet'
-            CASE(12)
-                cellnv(ic) = 5
-                cellnf(ic) = 5
-                cellgroup(ic) = -1
-                cellgeo(ic) = 'pyr'
-            CASE(14)
-                cellnv(ic) = 6
-                cellnf(ic) = 5
-                cellgroup(ic) = -1
-                cellgeo(ic) = 'pri'
-            CASE(17)
-                cellnv(ic) = 8
-                cellnf(ic) = 6
-                cellgroup(ic) = -1
-                cellgeo(ic) = 'hex'
-            CASE default
-                WRITE(*,*) 'WARNING! Unsupported CGNS type of cell: ', itype, ' IGNORING'
-                CONTINUE
-            END SELECT
-            i2 = i1 + cellnv(ic) - 1
-            i1 = i2 + 1
-            v2c%lookup(ic+1) = i1
-        END DO
-        j1 = v2c%lookup(istart)
-        j2 = v2c%lookup(iend+1)-1
-        CALL cg_elements_read_f(index_file,index_base,index_zone,index_sect,&
-            & work1_cg(j1:j2),iparentdata,ier)
-        IF(ier /= CG_OK) CALL cg_error_exit_f
-    END DO
-    CALL v2c%alloc_table(ntab=i2)
-
-    work1 = work1_cg
-    v2c%tab = work1(1:i2)
-    DEALLOCATE(work1)
-    DEALLOCATE(work1_cg)
-
-    ! Defines group
-    ! NOTE: only one group is currently supported
-    CALL c2g%alloc_table(nel=ngroups,ntab=ncells)
-
-    ALLOCATE(groupnc(ngroups),groupmat(ngroups),&
-        &   groupname(ngroups),stat=info)
-    IF(info /= 0) THEN
-        WRITE(*,100)
-        CALL abort_psblas
-    END IF
-
-    i1 = 1; i2 = 0; c2g%lookup(1) = 1
-    DO ig = 1, ngroups
-        groupnc(ig) = ncells
-        groupmat(ig) = 2        ! Default of Gambit
-        groupname(ig) = 'fluid' ! Default of Gambit
-        i2 = i1 + groupnc(ig) - 1
-        DO ic = i1, i2
-            c2g%tab(ic) = ic
-        END DO
-        i1 = i2 + 1
-        c2g%lookup(ig+1) = i1
-    END DO
-
-    ! Creates face-cell connectivity
-    ! NOTE: from here until reading of bcs the code is equal to import_neu.f90
-    !
-    ! Estimation of elements number for f2c%tab and v2f%tab
-    nfaces = 0; n = 0
-    DO ic = 1, ncells
-        j = cellnf(ic)
-        nfaces = nfaces + j
-        ! ---
-        SELECT CASE(cellgeo(ic))
-        CASE('qua')
-            k = 8
-        CASE('tri')
-            k = 6
-        CASE('hex')
-            k = 24
-        CASE('pri')
-            k = 18
-        CASE('tet')
-            k = 12
-        CASE('pyr')
-            k = 16
-        END SELECT
-        n = n + k
-    END DO
-
-    ! Allocation of face-related connectivity tables
-    CALL f2c%alloc_table(nel=ncells,ntab=nfaces)
-    CALL v2f%alloc_table(nel=nfaces,ntab=n)
-
-    ! Allocation of temporary face-related arrays
-    ALLOCATE(iflag(nfaces), fnv(nfaces),  &
-        &   imaster(nfaces), islave(nfaces), stat=info)
-    IF(info /= 0) THEN
-        WRITE(*,100)
-        CALL abort_psblas
-    END IF
-
-    i1 = 1; i2 = 0; f2c%lookup(1) = 1
-    j1 = 1; j2 = 0; v2f%lookup(1) = 1
-    DO ic = 1, ncells
-        i2 = i1 + cellnf(ic) - 1
+        !! @note Compatible only with CGNS v3.3.0 and above. Earlier versions are not supported.
+        !! Note: CGNS functionality is not working for FAST. Currently set to pre-process entire module procedure
+        !!       so that the implementation exists but is empty. IP - 6/6/2019
+        USE cgns, ONLY : cg_vertex       => vertex, & ! avoids "vertex" name conflict with class_vertex.f90
+            & CG_Unstructured => Unstructured, &
+            & CG_BAR_2        => BAR_2, &
+            & CG_TRI_3        => TRI_3, &
+            & CG_QUAD_4       => QUAD_4, &
+            & CG_TETRA_4      => TETRA_4, &
+            & CG_PYRA_5       => PYRA_5, &
+            & CG_PENTA_6      => PENTA_6, &
+            & CG_HEXA_8       => HEXA_8, &
+            & CG_MODE_READ, &
+            & cgenum_t, &
+            & cgsize_t, &
+            & CG_OK, &
+            & cg_nbases_f, &
+            & cg_nzones_f, &
+            & cg_nbocos_f, &
+            & cg_error_exit_f, &
+            & cg_nsections_f, &
+            & cg_close_f
+        USE class_psblas
+        USE class_cell
+        USE class_connectivity
+        USE class_face
+        USE class_vertex
+        USE tools_math
+        USE type_table, ONLY : table, alloc_table, free_table, get_dual_table
+        IMPLICIT NONE
         !
-        iv = v2c%lookup(ic) - 1
-        iv1 = v2c%tab(iv+1)
-        iv2 = v2c%tab(iv+2)
-        iv3 = v2c%tab(iv+3)
-        IF(cellnv(ic) > 3) iv4 = v2c%tab(iv+4) ! quad, tet
-        IF(cellnv(ic) > 4) iv5 = v2c%tab(iv+5) ! pyr
-        IF(cellnv(ic) > 5) iv6 = v2c%tab(iv+6) ! pri
-        IF(cellnv(ic) > 7) THEN ! hex
-            iv7 = v2c%tab(iv+7)
-            iv8 = v2c%tab(iv+8)
+        INTEGER, PARAMETER :: nlen = 80
+        !
+        ! --- Local variables ---
+        !
+        ! Parameters
+        LOGICAL, PARAMETER :: debug = .FALSE.
+        INTEGER, PARAMETER :: mesh = 10
+        INTEGER, PARAMETER :: MAX_LEN = 32
+        !
+        ! CGNS variables
+        INTEGER :: index_file, index_base, index_zone, index_sect, ier
+        INTEGER :: cell_dim, phys_dim, nbocos, nsections
+        INTEGER :: itype, istart, iend, nbndry, iparent_flag, iparentdata
+        INTEGER :: bocotype, ptset_type
+        INTEGER :: NormalIndex, NormalListFlag, NormalDataType, NormalList, ndataset
+        INTEGER :: isect_cell, isect_bc
+        CHARACTER(len=32) :: basename, zonename, sectionname
+        INTEGER(cgenum_t) :: type_coordinate_data
+        INTEGER(cgsize_t) :: isize(3)
+        CHARACTER(len=MAX_LEN) :: name_coordinate
+        INTEGER :: type_file
+        !
+        ! Local copies of V2F_, V2C_, F2C_ objects (connectivity class)
+        TYPE(table) :: v2f, v2c, f2c
+        !
+        ! Vertex-related variables
+        INTEGER :: nverts
+        INTEGER(cgsize_t) :: vertsmax !! number of vertices
+        INTEGER(cgsize_t) :: vertsmin=1
+        LOGICAL, ALLOCATABLE :: on_boundary(:)
+        REAL(psb_dpk_), ALLOCATABLE :: xv(:), yv(:), zv(:)
+        !
+        ! Face-related variables
+        INTEGER :: nfaces
+        INTEGER, ALLOCATABLE :: fnv(:), imaster(:), islave(:), iflag(:)
+        INTEGER, ALLOCATABLE :: facenv(:), facemaster(:), faceslave(:), faceflag(:)
+        !
+        ! Cell-related variables
+        INTEGER :: ncells
+        INTEGER, ALLOCATABLE :: cellnv(:), cellnf(:), cellgroup(:)
+        CHARACTER(len=3), ALLOCATABLE :: cellgeo(:)
+        !
+        ! Group-related variables
+        INTEGER :: ngroups
+        INTEGER, ALLOCATABLE :: groupnc(:), groupmat(:)
+        CHARACTER(len=32), ALLOCATABLE :: groupname(:)
+        TYPE(table) :: c2g
+        !
+        ! BC-related variables
+        INTEGER :: nbcfaces
+        INTEGER, ALLOCATABLE :: bcnf(:)
+        INTEGER(cgsize_t), ALLOCATABLE :: bcnf_cg(:)
+        CHARACTER(len=32), ALLOCATABLE :: bcname(:)
+        TYPE(table) :: f2b, bcface
+        !
+        ! Work variables
+        LOGICAL :: found
+        INTEGER :: i, i1, i2, info, j, j1, j2, k,k1, k2, l, m, n
+        INTEGER :: ib, ic, ig
+        INTEGER :: IF, if1, if2
+        INTEGER :: iv, iv1, iv2, iv3, iv4, iv5, iv6, iv7, iv8
+        INTEGER, ALLOCATABLE :: perm(:), pinv(:)
+        INTEGER, ALLOCATABLE :: aux(:,:), buf(:), work1(:), work2(:)
+        INTEGER(cgsize_t), ALLOCATABLE :: work1_cg(:), f2btab_cg(:), bcfacetab_cg(:)
+        TYPE(table) :: dmy, f2v
+
+        ! ------------------------------------------------------------------
+
+        WRITE(*,*) 'Importing mesh in .CGNS format on P0'
+
+        ! Check file type
+        CALL cg_is_cgns_f(TRIM(ADJUSTL(mesh_file)),type_file,ier)
+        IF(ier /= CG_OK) THEN
+            WRITE (*,*) 'ERROR! Unsupported file format'
+            CALL abort_psblas
         END IF
-        DO IF = i1, i2
-            f2c%tab(IF) = IF
-            iflag(IF) = 0
-            imaster(IF) = ic
-            islave(IF) = 0 ! Further defined
-        END DO
 
-        ! NOTE: standard connectivity vertices-cells defined in SIDS_guide
-        SELECT CASE(cellgeo(ic))
-        CASE('qua')
-            j2 = j1 + 8 - 1
-            v2f%tab(j1:j2) = (/ iv1,iv2, iv2,iv3, iv3,iv4, iv4,iv1 /)
-            v2f%lookup(i1:i2) = (/ j1, (j1+2), (j1+4), (j1+6) /)
-            fnv(i1:i2) = (/ 2, 2, 2, 2 /)
-        CASE('tri')
-            j2 = j1 + 6 - 1
-            v2f%tab(j1:j2) = (/ iv1,iv2, iv2,iv3, iv3,iv1 /)
-            v2f%lookup(i1:i2) = (/ j1, (j1+2), (j1+4) /)
-            fnv(i1:i2) = (/ 2, 2, 2 /)
-        CASE('hex')
-            j2 = j1 + 24 - 1
-            v2f%tab(j1:j2) = (/ iv1,iv4,iv3,iv2, iv1,iv2,iv6,iv5, iv2,iv3,iv7,iv6, &
-                &              iv3,iv4,iv8,iv7, iv1,iv5,iv8,iv4, iv5,iv6,iv7,iv8 /)
-            v2f%lookup(i1:i2) = (/ j1, (j1+4), (j1+8), (j1+12), (j1+16), (j1+20) /)
-            fnv(i1:i2) = (/ 4, 4, 4, 4, 4, 4 /)
-        CASE('pri')
-            j2 = j1 + 18 - 1
-            v2f%tab(j1:j2) = (/ iv1,iv2,iv5,iv4, iv2,iv3,iv6,iv5, iv3,iv1,iv4,iv6, &
-                &              iv1,iv3,iv2, iv4,iv5,iv6 /)
-            v2f%lookup(i1:i2) = (/ j1, (j1+4), (j1+8), (j1+12), (j1+15) /)
-            fnv(i1:i2) = (/ 4, 4, 4, 3, 3  /)
-        CASE('tet')
-            j2 = j1 + 12 - 1
-            v2f%tab(j1:j2) = (/ iv1,iv3,iv2, iv1,iv2,iv4, iv2,iv3,iv4, iv3,iv1,iv4 /)
-            v2f%lookup(i1:i2) = (/ j1, (j1+3), (j1+6), (j1+9) /)
-            fnv(i1:i2) = (/ 3, 3, 3, 3  /)
-        CASE('pyr')
-            j2 = j1 + 16 - 1
-            v2f%tab(j1:j2) = (/ iv1,iv4,iv3,iv2, iv1,iv2,iv5, iv2,iv3,iv5, &
-                &              iv3,iv4,iv5, iv4,iv1,iv5 /)
-            v2f%lookup(i1:i2) = (/ j1, (j1+4), (j1+7), (j1+10), (j1+13) /)
-            fnv(i1:i2) = (/ 4, 3, 3, 3, 3  /)
-        END SELECT
-        ! ---
-        i1 = i2 + 1
-        j1 = j2 + 1
-        f2c%lookup(ic+1) = i1
-        v2f%lookup(i2+1) = j1
-    END DO
+        ! Opens file *.cgns
+        CALL cg_open_f(TRIM(ADJUSTL(mesh_file)),CG_MODE_READ,index_file,ier)
+        IF(ier /= CG_OK) CALL cg_error_exit_f
 
-    ! #############################################################################
-    IF(debug) THEN
-        DO ic = 1, ncells
-            i1 = f2c%lookup(ic)
-            i2 = f2c%lookup(ic+1) - 1
-            j1 = f2c%tab(i1)
-            j2 = f2c%tab(i2)
-            DO IF = j1, j2
-                iv1 = v2f%lookup(IF)
-                iv2 = v2f%lookup(IF+1) - 1
-                WRITE(*,320) ic, cellgeo(ic), IF, v2f%tab(iv1:iv2);
-            END DO
-        END DO
-        WRITE(*,*)
-320     FORMAT(' cell: ',i5,' type: ',a3, ' face: ',i6,' vertices:', 8(1x,i5))
-    END IF
-    ! ###########################################################################
+        ! Finds number of bases and zones
+        ! NOTE: Only one base and one zone per base are assumed respectively
+        CALL cg_nbases_f(index_file,index_base,ier)
+        IF(ier /= CG_OK) CALL cg_error_exit_f
 
-    ! Builds connection table f2v, dual of v2f
-    CALL get_dual_table(v2f,f2v)
+        IF (index_base /= 1) THEN
+            WRITE (*,*) 'ERROR! Unsupported number of CGNS bases'
+            CALL abort_psblas
+        END IF
+        CALL cg_nzones_f(index_file,index_base,index_zone,ier)
+        IF (index_zone /= 1) THEN
+            WRITE (*,*) 'ERROR! Unsupported number of CGNS zones'
+            CALL abort_psblas
+        END IF
 
-    ! Initializes face permutation array
-    ALLOCATE(perm(nfaces), stat=info)
-    IF(info /= 0) THEN
-        WRITE(*,100)
-        CALL abort_psblas
-    END IF
-    DO IF = 1, nfaces
-        perm(IF) = IF
-    END DO
+        ! mesh ID and global parameters
+        CALL cg_base_read_f(index_file,index_base,basename,cell_dim,phys_dim,ier)
+        IF(ier /= CG_OK) CALL cg_error_exit_f
+        CALL cg_zone_read_f(index_file,index_base,index_zone,zonename,isize,ier)
+        IF(ier /= CG_OK) CALL cg_error_exit_f
+        CALL cg_nbocos_f(index_file,index_base,index_zone,nbocos,ier)
+        IF(ier /= CG_OK) CALL cg_error_exit_f
+        mesh_id = zonename
+        nverts = isize(1)
+        ncells = isize(2)
+        vertsmax = nverts
 
-    ! Locates repeated faces and sets their flags = -1
-    IF(ncd == 2) THEN
-        pile_2D:  DO iv = 1, nverts
-            i = f2v%lookup(iv) - 1 ! Offset
-            n = f2v%lookup(iv+1) - f2v%lookup(iv) ! # of elements
-            if1_2D: DO j = 1, n
-                if1 = f2v%tab(i+j)
-                IF(iflag(if1) == -1 .OR. islave(if1) /= 0) CYCLE
-                i1 = v2f%lookup(if1) - 1
-                iv1 = v2f%tab(i1+1) ! 1st iv of if1
-                iv2 = v2f%tab(i1+2) ! 2nd iv of if1
-                if2_2D: DO k = j + 1, n
-                    if2 = f2v%tab(i+k)
-                    i2 = v2f%lookup(if2)-1
-                    iv3 = v2f%tab(i2+1) ! 1st iv of if2
-                    iv4 = v2f%tab(i2+2) ! 2nd iv of if2
-                    !---
-                    IF(iv4 == iv1 .AND. iv3 == iv2) THEN
-                        iflag(if2) = -1
-                        islave(if1) = imaster(if2)
-                        imaster(if2) = 0
-                        perm(if2) = if1
-                        EXIT if2_2D
-                    END IF
-                END DO if2_2D
-            END DO if1_2D
-        END DO pile_2D
-    ELSE IF(ncd == 3) THEN
-        ALLOCATE(buf(6),stat=info)
+        ! By default isize(3) is equal to 0
+        ngroups = 1 ! TO DO: how to manage multiple groups?
+        nbc = nbocos
+        ncd = cell_dim
+        IF(ncd /= 2.AND.ncd /= 3) THEN
+            WRITE(*,*) 'ERROR! NCD in CGNS file must be 2 or 3'
+            CALL abort_psblas
+        END IF
+
+        ! #############################################################################
+        IF(debug) THEN
+            WRITE(*,*)
+            WRITE(*,300) TRIM(mesh_id), nverts, ncells, ngroups, nbc, ncd
+            WRITE(*,*)
+300         FORMAT(' meshid: ',a,' nverts: ',i6,' ncells: ',i6,' ngroups ',i2,&
+                & ' nbc: ',i2,' ncd: ',i2)
+        END IF
+        ! #############################################################################
+
+        ALLOCATE (xv(nverts), yv(nverts), zv(nverts), &
+            & cellnv(ncells), cellnf(ncells), cellgeo(ncells), cellgroup(ncells), &
+            & stat=info)
         IF(info /= 0) THEN
-            WRITE(*,100)
-            CALL abort_psblas
-        END IF
-        ! ---
-        pile_3D:  DO iv = 1, nverts
-            i = f2v%lookup(iv) - 1! Offset
-            n = f2v%lookup(iv+1) - f2v%lookup(iv) ! # of elements
-            if1_3D: DO j = 1, n - 1
-                if1 = f2v%tab(i+j)
-                IF(iflag(if1) == -1 .OR. islave(if1) /= 0) CYCLE
-                ! iflag(if1) = -1  --> repeated face
-                ! islave(if1) /= 0 --> already examinated face
-                i1 = v2f%lookup(if1) - 1
-                iv1 = v2f%tab(i1+1)
-                iv2 = v2f%tab(i1+2)
-                iv3 = v2f%tab(i1+3)
-                found = .FALSE.
-                if2_3D: DO k = j + 1, n
-                    if2 = f2v%tab(i+k)
-                    i2 = v2f%lookup(if2)
-                    j2 = v2f%lookup(if2+1)-1
-                    l = fnv(if2)
-                    ! Copies if2 iv-sequence in buf
-                    buf(1) = v2f%tab(j2)
-                    buf(2:(l+1)) = v2f%tab(i2:j2)
-                    buf(l+2) = v2f%tab(i2)
-                    IF(l == 3) buf(6)=0
-                    !---
-                    ! Searches for iv2 in buf
-                    match: DO m = 2, (l+1)
-                        IF(buf(m) /= iv2) CYCLE
-                        IF(buf(m+1) == iv1 .AND. buf(m-1) == iv3) THEN
-                            iflag(if2) = -1
-                            islave(if1) = imaster(if2)
-                            imaster(if2) = 0
-                            perm(if2) = if1
-                            found = .TRUE.
-                        END IF
-                    END DO match
-                    IF(found) EXIT if2_3D
-                END DO if2_3D
-            END DO if1_3D
-        END DO pile_3D
-        DEALLOCATE(buf)
-    END IF
-    CALL f2v%free_table()
-
-    ! ###########################################################################
-    IF (debug) THEN
-        DO IF = 1, nfaces
-            WRITE(*,330) IF, iflag(IF), imaster(IF), islave(IF)
-        END DO
-        WRITE(*,*)
-330     FORMAT(' face: ',i4,' flag: ',i2,' master: ',i4,' slave: ',i4)
-    END IF
-    ! ###########################################################################
-
-    ! Completes definition of permutation array
-    ! new=perm(old)
-    ! old=pinv(new)
-    !
-    ! By first faces with iflag(if)=0 ...
-    j = 0
-    DO IF = 1, nfaces
-        IF(iflag(IF) == 0) THEN
-            j = j + 1
-            perm(IF) = j
-        END IF
-    END DO
-    ! ... then faces with iflag(if)=-1
-    DO IF = 1, nfaces
-        IF(iflag(IF) == -1) THEN
-            j = perm(IF)
-            perm(IF) = perm(j)
-        END IF
-    END DO
-
-    ! ###########################################################################
-    IF(debug) THEN
-        n = COUNT(iflag == 0)
-        DO IF = 1, nfaces
-            i1 = v2f%lookup(IF)
-            k = fnv(IF)
-            WRITE(*,340) IF, iflag(IF), perm(IF), (v2f%tab(j), j = i1, i1+k-1)
-        END DO
-        WRITE(*,*)
-        DO IF = 1,nfaces
-            i1 = v2f%lookup(IF)
-            k = fnv(IF)
-        END DO
-340     FORMAT(' face: ',i5,' flag: ',i2,' perm: ',i5,' vertices',4i5)
-    END IF
-    ! ###########################################################################
-
-    ! Reordering of face based arrays
-
-    ! Updates NFACES and stores OLD NFACES in N
-    n = nfaces
-    nfaces = COUNT(iflag == 0)
-
-    ! Allocation of PINV and definitive face-related arrays
-    ALLOCATE(pinv(nfaces), facenv(nfaces), faceflag(nfaces),&
-        & facemaster(nfaces), faceslave(nfaces), stat=info)
-    IF(info /= 0) THEN
-        WRITE(*,100)
-        CALL abort_psblas
-    END IF
-
-    ! Builds inverse permutation array for the NEW first NFACES faces
-    DO IF = 1, n
-        IF (iflag(IF) == 0) THEN
-            j = perm(IF)
-            pinv(j) = IF
-        END IF
-    END DO
-
-    ! Reordering and definition of FACE face-object
-    DO IF = 1, nfaces
-        j = pinv(IF)
-
-        facenv(IF)     = fnv(j)
-        faceflag(IF)   = 0
-        facemaster(IF) = imaster(j)
-        faceslave(IF)  = islave(j)
-    END DO
-    DEALLOCATE(iflag,imaster,islave,fnv)
-
-    ! Reordering and reallocation of v2f
-    k = 0
-    DO IF = 1, nfaces
-        j = k
-        k = j + facenv(IF)
-    END DO
-    !
-    CALL dmy%alloc_table(nel=nfaces,ntab=k)
-    i1 = 1; i2 = 0; dmy%lookup(1) = 1
-    DO IF = 1, nfaces
-        j = pinv(IF)
-        i2 = i1 + facenv(IF) - 1
-        j1 = v2f%lookup(j)
-        j2 = j1 + facenv(IF) - 1
-        dmy%tab(i1:i2) = v2f%tab(j1:j2)
-        i1 = i2 + 1
-        dmy%lookup(IF+1) = i1
-    END DO
-    CALL v2f%free_table()
-
-    CALL v2f%alloc_table(nel=nfaces,ntab=k)
-    v2f%lookup = dmy%lookup(1:nfaces+1)
-    v2f%tab = dmy%tab(1:k)
-
-    ! Reordering of f2c%tab
-    DO ic = 1, ncells
-        i1 = f2c%lookup(ic)
-        i2 = f2c%lookup(ic+1) - 1
-        DO i = i1, i2
-            j = f2c%tab(i)
-            f2c%tab(i) = perm(j)
-        END DO
-    END DO
-
-    CALL dmy%free_table()
-    DEALLOCATE(perm,pinv)
-
-    ! ###########################################################################
-    IF(debug) THEN
-        DO IF = 1, nfaces
-            i1 = v2f%lookup(IF)
-            i2 = v2f%lookup(IF+1) - 1
-            WRITE(*,350) IF, facemaster(IF), faceslave(IF), v2f%tab(i1:i2)
-        END DO
-        WRITE(*,*)
-        DO ic = 1, ncells
-            i1 = f2c%lookup(ic)
-            i2 = f2c%lookup(ic+1) - 1
-            WRITE(*,360) ic, f2c%tab(i1:i2)
-        END DO
-        WRITE(*,*)
-350     FORMAT(' face: ',i5,' master: ',i5,' slave: ',i5,' vertices: ',4i5)
-360     FORMAT(' cell: ',i5, ' faces:',6(1x,i5))
-    END IF
-    ! ###########################################################################
-
-    ! --- Reads and assigns boundary conditions. Boundary flags are integer
-    ! in the range [1-NBC]. If NBC=0 from import, automatically NBC=1 and where
-    ! faceslave=0 a boundary face is asssumed.
-    ! --- Builds list of faces, grouping them by their flag value.
-    !
-    ! iflag(if)=0 --> fluid face
-    ! iflag(if)=i --> i-th boundary face
-    !
-
-    ! Counts boundary faces (faceslave = 0)
-    k = COUNT(faceslave == 0)
-
-    IF(nbc /= 0) THEN
-        CALL f2b%alloc_table(nel=nbc,ntab=k)
-        ALLOCATE(bcnf(nbc),bcname(nbc),stat=info)
-    ELSE
-        CALL f2b%alloc_table(nel=1,ntab=k)
-        ALLOCATE(bcnf(1),bcname(1),stat=info)
-    END IF
-    IF(info /= 0) THEN
-        WRITE(*,100)
-        CALL abort_psblas
-    END IF
-    ALLOCATE(f2btab_cg(k), stat=info)
-    IF(info /= 0) THEN
-        WRITE(*,100)
-        CALL abort_psblas
-    END IF
-    ALLOCATE(bcnf_cg(SIZE(bcnf)), stat=info)
-    IF(info /= 0) THEN
-        WRITE(*,100)
-        CALL abort_psblas
-    END IF
-
-    ! Reads bc section
-    IF(nbc /= 0) THEN
-        i1 = 1; i2 = 0; f2b%lookup(1) = i1
-        DO ib = 1, nbc
-            CALL cg_boco_info_f(index_file,index_base,index_zone,ib,&
-                & bcname(ib),bocotype,ptset_type,bcnf_cg(ib),&
-                & NormalIndex,NormalListFlag,NormalDataType,ndataset,ier)
-            IF(ier /= CG_OK) CALL cg_error_exit_f
-            ! NOTE: NORMAL* and NDATASET are unused
-            bcnf(ib) = bcnf_cg(ib)
-
-            i2 = i1 + bcnf(ib) - 1
-            CALL cg_boco_read_f(index_file,index_base,index_zone,ib,&
-                & f2btab_cg(i1:i2),NormalList,ier)
-            IF(ier /= CG_OK) CALL cg_error_exit_f
-            f2b%tab(i1:i2) = f2btab_cg(i1:i2)
-            i1 = i2 + 1
-            f2b%lookup(ib+1) = i1
-        END DO
-        ! N = number of BC faces
-        n = f2b%lookup(nbc+1) - 1
-
-        ! Check on the consistency of bc faces
-        IF(n /= COUNT(faceslave == 0)) THEN
-            WRITE(*,*) 'ERROR! Inconsistent number of bc faces in CGNS file'
+            WRITE (*,100)
             CALL abort_psblas
         END IF
 
-        !
-        ! Counts records and elements of bc-sections; to use in the successive
-        ! allocation of bcface%lookup, bcface%tab.
-        ! NOTE: this is necessary because it can happen that the total amount of records in
-        ! presumed 'bc'-section is greater than the effective number of bc faces.
-        ! --> to be investigated more deeply in ICEM!
-        k1 = 0; k2 = 0
-        DO index_sect = isect_cell + 1, isect_bc
+        ! Check coordinate data type
+        CALL cg_coord_info_f(index_file, index_base, index_zone, 1, type_coordinate_data, name_coordinate, ier)
+        IF(ier /= CG_OK) CALL cg_error_exit_f()
+
+        ! Reads vertices coordinates
+        CALL cg_coord_read_f(index_file,index_base,index_zone,'CoordinateX',&
+            &  type_coordinate_data,vertsmin,vertsmax,xv,ier)
+        IF(ier /= CG_OK) CALL cg_error_exit_f
+        CALL cg_coord_read_f(index_file,index_base,index_zone,'CoordinateY',&
+            & type_coordinate_data,vertsmin,vertsmax,yv,ier)
+        IF(ier /= CG_OK) CALL cg_error_exit_f
+        CALL cg_coord_read_f(index_file,index_base,index_zone,'CoordinateZ',&
+            & type_coordinate_data,vertsmin,vertsmax,zv,ier)
+        IF(ier /= CG_OK) CALL cg_error_exit_f
+
+        ! #############################################################################
+        IF(debug) THEN
+            DO iv = 1, nverts
+                WRITE(*,310) iv, xv(iv), yv(iv), zv(iv)
+            END DO
+            WRITE(*,*)
+310         FORMAT(' vertex: ',i5,' | ','coordinates: ',3(1x,d13.6))
+        END IF
+        ! #############################################################################
+
+        ! Finds number of sections in CGNS file
+        CALL cg_nsections_f(index_file,index_base,index_zone,nsections,ier)
+        IF(ier /= CG_OK) CALL cg_error_exit_f
+
+        ! k = number of sections containing cell elements
+        DO index_sect = 1, nsections
             CALL cg_section_read_f(index_file,index_base,index_zone,index_sect,&
                 & sectionname,itype,istart,iend,nbndry,iparent_flag,ier)
             IF(ier /= CG_OK) CALL cg_error_exit_f
-            n = iend - istart + 1 ! Number of records, i.e. faces, inside the bc-section
-            k1 = k1 + n           ! Increases bcface%lookup elements number
-            SELECT CASE(itype)
-            CASE(3) ! bar
-                l=2
-            CASE(5) ! tri
-                l=3
-            CASE(7) ! quad
-                l=4
-            CASE default
-                WRITE(*,*) 'WARNING! Unsupported type of CGNS bc element: itype =', itype, 'IGNORING'
-                CONTINUE
-            END SELECT
-            k2=k2+n*l ! Increases bcface%tab elements number
+            IF (iend == ncells) THEN
+                isect_cell = index_sect
+                EXIT
+            END IF
         END DO
+        isect_bc=nsections
 
-        ! Allocates bcface%lookup, bcface%tab
-        CALL bcface%alloc_table(nel=k1,ntab=k2)
-        ALLOCATE(bcfacetab_cg(k2), stat=info)
+        ! Reads sections containing vertex-to-cell connectivities
+        IF(ncd == 2) THEN
+            n = 4 * ncells
+        ELSE IF(ncd == 3) THEN
+            n = 8 * ncells
+        END IF
+        ALLOCATE(work1(n),stat=info)
         IF(info /= 0) THEN
             WRITE(*,100)
             CALL abort_psblas
         END IF
 
-        ! Reads sections containing boundary elements
-        bcface%lookup(1) = 1
-        DO index_sect = isect_cell + 1, isect_bc
+        ALLOCATE(work1_cg(n),stat=info)
+        IF(info /= 0) THEN
+            WRITE(*,100)
+            CALL abort_psblas
+        END IF
+
+        CALL v2c%alloc_table(nel=ncells)
+
+        work1 = 0
+        work1_cg = 0
+        i1 = 1; i2 = 0; v2c%lookup(i1) = 1
+        DO index_sect = 1, isect_cell
             CALL cg_section_read_f(index_file,index_base,index_zone,index_sect,&
                 & sectionname,itype,istart,iend,nbndry,iparent_flag,ier)
             IF(ier /= CG_OK) CALL cg_error_exit_f
-            SELECT CASE(itype)
-            CASE(3) ! bar
-                l = 2
-            CASE(5) ! tri
-                l = 3
-            CASE(7) ! quad
-                l = 4
-            CASE default
-                WRITE(*,*) 'WARNING! Unsupported type of CGNS bc element: itype =', itype, 'IGNORING'
-                CONTINUE
-            END SELECT
-            i1 = istart - ncells
-            i2 = iend - ncells
-            DO i = i1, i2
-                bcface%lookup(i+1) = bcface%lookup(i) + l
+            DO ic = istart, iend
+                SELECT CASE(itype)
+                CASE(5)
+                    cellnv(ic) = 3
+                    cellnf(ic) = 3
+                    cellgroup(ic) = -1
+                    cellgeo(ic) ='tri'
+                CASE(7)
+                    cellnv(ic) = 4
+                    cellnf(ic) = 4
+                    cellgroup(ic) = -1
+                    cellgeo(ic) = 'qua'
+                CASE(10)
+                    cellnv(ic) = 4
+                    cellnf(ic) = 4
+                    cellgroup(ic) = -1
+                    cellgeo(ic) = 'tet'
+                CASE(12)
+                    cellnv(ic) = 5
+                    cellnf(ic) = 5
+                    cellgroup(ic) = -1
+                    cellgeo(ic) = 'pyr'
+                CASE(14)
+                    cellnv(ic) = 6
+                    cellnf(ic) = 5
+                    cellgroup(ic) = -1
+                    cellgeo(ic) = 'pri'
+                CASE(17)
+                    cellnv(ic) = 8
+                    cellnf(ic) = 6
+                    cellgroup(ic) = -1
+                    cellgeo(ic) = 'hex'
+                CASE default
+                    WRITE(*,*) 'WARNING! Unsupported CGNS type of cell: ', itype, ' IGNORING'
+                    CONTINUE
+                END SELECT
+                i2 = i1 + cellnv(ic) - 1
+                i1 = i2 + 1
+                v2c%lookup(ic+1) = i1
             END DO
-            j1 = bcface%lookup(i1)
-            j2 = bcface%lookup(i2+1) - 1
+            j1 = v2c%lookup(istart)
+            j2 = v2c%lookup(iend+1)-1
             CALL cg_elements_read_f(index_file,index_base,index_zone,index_sect,&
-                & bcfacetab_cg(j1:j2),iparentdata,ier)
+                & work1_cg(j1:j2),iparentdata,ier)
             IF(ier /= CG_OK) CALL cg_error_exit_f
-            bcface%tab(j1:j2) = bcfacetab_cg(j1:j2)
+        END DO
+        CALL v2c%alloc_table(ntab=i2)
+
+        work1 = work1_cg
+        v2c%tab = work1(1:i2)
+        DEALLOCATE(work1)
+        DEALLOCATE(work1_cg)
+
+        ! Defines group
+        ! NOTE: only one group is currently supported
+        CALL c2g%alloc_table(nel=ngroups,ntab=ncells)
+
+        ALLOCATE(groupnc(ngroups),groupmat(ngroups),&
+            &   groupname(ngroups),stat=info)
+        IF(info /= 0) THEN
+            WRITE(*,100)
+            CALL abort_psblas
+        END IF
+
+        i1 = 1; i2 = 0; c2g%lookup(1) = 1
+        DO ig = 1, ngroups
+            groupnc(ig) = ncells
+            groupmat(ig) = 2        ! Default of Gambit
+            groupname(ig) = 'fluid' ! Default of Gambit
+            i2 = i1 + groupnc(ig) - 1
+            DO ic = i1, i2
+                c2g%tab(ic) = ic
+            END DO
+            i1 = i2 + 1
+            c2g%lookup(ig+1) = i1
         END DO
 
-        DEALLOCATE(bcfacetab_cg)
+        ! Creates face-cell connectivity
+        ! NOTE: from here until reading of bcs the code is equal to import_neu.f90
+        !
+        ! Estimation of elements number for f2c%tab and v2f%tab
+        nfaces = 0; n = 0
+        DO ic = 1, ncells
+            j = cellnf(ic)
+            nfaces = nfaces + j
+            ! ---
+            SELECT CASE(cellgeo(ic))
+            CASE('qua')
+                k = 8
+            CASE('tri')
+                k = 6
+            CASE('hex')
+                k = 24
+            CASE('pri')
+                k = 18
+            CASE('tet')
+                k = 12
+            CASE('pyr')
+                k = 16
+            END SELECT
+            n = n + k
+        END DO
+
+        ! Allocation of face-related connectivity tables
+        CALL f2c%alloc_table(nel=ncells,ntab=nfaces)
+        CALL v2f%alloc_table(nel=nfaces,ntab=n)
+
+        ! Allocation of temporary face-related arrays
+        ALLOCATE(iflag(nfaces), fnv(nfaces),  &
+            &   imaster(nfaces), islave(nfaces), stat=info)
+        IF(info /= 0) THEN
+            WRITE(*,100)
+            CALL abort_psblas
+        END IF
+
+        i1 = 1; i2 = 0; f2c%lookup(1) = 1
+        j1 = 1; j2 = 0; v2f%lookup(1) = 1
+        DO ic = 1, ncells
+            i2 = i1 + cellnf(ic) - 1
+            !
+            iv = v2c%lookup(ic) - 1
+            iv1 = v2c%tab(iv+1)
+            iv2 = v2c%tab(iv+2)
+            iv3 = v2c%tab(iv+3)
+            IF(cellnv(ic) > 3) iv4 = v2c%tab(iv+4) ! quad, tet
+            IF(cellnv(ic) > 4) iv5 = v2c%tab(iv+5) ! pyr
+            IF(cellnv(ic) > 5) iv6 = v2c%tab(iv+6) ! pri
+            IF(cellnv(ic) > 7) THEN ! hex
+                iv7 = v2c%tab(iv+7)
+                iv8 = v2c%tab(iv+8)
+            END IF
+            DO IF = i1, i2
+                f2c%tab(IF) = IF
+                iflag(IF) = 0
+                imaster(IF) = ic
+                islave(IF) = 0 ! Further defined
+            END DO
+
+            ! NOTE: standard connectivity vertices-cells defined in SIDS_guide
+            SELECT CASE(cellgeo(ic))
+            CASE('qua')
+                j2 = j1 + 8 - 1
+                v2f%tab(j1:j2) = (/ iv1,iv2, iv2,iv3, iv3,iv4, iv4,iv1 /)
+                v2f%lookup(i1:i2) = (/ j1, (j1+2), (j1+4), (j1+6) /)
+                fnv(i1:i2) = (/ 2, 2, 2, 2 /)
+            CASE('tri')
+                j2 = j1 + 6 - 1
+                v2f%tab(j1:j2) = (/ iv1,iv2, iv2,iv3, iv3,iv1 /)
+                v2f%lookup(i1:i2) = (/ j1, (j1+2), (j1+4) /)
+                fnv(i1:i2) = (/ 2, 2, 2 /)
+            CASE('hex')
+                j2 = j1 + 24 - 1
+                v2f%tab(j1:j2) = (/ iv1,iv4,iv3,iv2, iv1,iv2,iv6,iv5, iv2,iv3,iv7,iv6, &
+                    &              iv3,iv4,iv8,iv7, iv1,iv5,iv8,iv4, iv5,iv6,iv7,iv8 /)
+                v2f%lookup(i1:i2) = (/ j1, (j1+4), (j1+8), (j1+12), (j1+16), (j1+20) /)
+                fnv(i1:i2) = (/ 4, 4, 4, 4, 4, 4 /)
+            CASE('pri')
+                j2 = j1 + 18 - 1
+                v2f%tab(j1:j2) = (/ iv1,iv2,iv5,iv4, iv2,iv3,iv6,iv5, iv3,iv1,iv4,iv6, &
+                    &              iv1,iv3,iv2, iv4,iv5,iv6 /)
+                v2f%lookup(i1:i2) = (/ j1, (j1+4), (j1+8), (j1+12), (j1+15) /)
+                fnv(i1:i2) = (/ 4, 4, 4, 3, 3  /)
+            CASE('tet')
+                j2 = j1 + 12 - 1
+                v2f%tab(j1:j2) = (/ iv1,iv3,iv2, iv1,iv2,iv4, iv2,iv3,iv4, iv3,iv1,iv4 /)
+                v2f%lookup(i1:i2) = (/ j1, (j1+3), (j1+6), (j1+9) /)
+                fnv(i1:i2) = (/ 3, 3, 3, 3  /)
+            CASE('pyr')
+                j2 = j1 + 16 - 1
+                v2f%tab(j1:j2) = (/ iv1,iv4,iv3,iv2, iv1,iv2,iv5, iv2,iv3,iv5, &
+                    &              iv3,iv4,iv5, iv4,iv1,iv5 /)
+                v2f%lookup(i1:i2) = (/ j1, (j1+4), (j1+7), (j1+10), (j1+13) /)
+                fnv(i1:i2) = (/ 4, 3, 3, 3, 3  /)
+            END SELECT
+            ! ---
+            i1 = i2 + 1
+            j1 = j2 + 1
+            f2c%lookup(ic+1) = i1
+            v2f%lookup(i2+1) = j1
+        END DO
+
+        ! #############################################################################
+        IF(debug) THEN
+            DO ic = 1, ncells
+                i1 = f2c%lookup(ic)
+                i2 = f2c%lookup(ic+1) - 1
+                j1 = f2c%tab(i1)
+                j2 = f2c%tab(i2)
+                DO IF = j1, j2
+                    iv1 = v2f%lookup(IF)
+                    iv2 = v2f%lookup(IF+1) - 1
+                    WRITE(*,320) ic, cellgeo(ic), IF, v2f%tab(iv1:iv2);
+                END DO
+            END DO
+            WRITE(*,*)
+320         FORMAT(' cell: ',i5,' type: ',a3, ' face: ',i6,' vertices:', 8(1x,i5))
+        END IF
+        ! ###########################################################################
 
         ! Builds connection table f2v, dual of v2f
         CALL get_dual_table(v2f,f2v)
 
-        ! Associates bc elements to corresponding faces
-        IF(ncd == 2) THEN
-            ib_2D: DO ib = 1, nbc
-                i1 = f2b%lookup(ib)
-                i2 = f2b%lookup(ib+1) - 1
-                bcface_2D: DO i = i1, i2
-                    if1 = f2b%tab(i) - ncells ! Offset of cell-sections
-                    k = bcface%lookup(if1)
-                    ! NOTE: ICEM don't respect on bc elements the right hand ordering!!
-                    ! => for successive benchmark forces iv1 < iv2
-                    iv1 = bcface%tab(k)
-                    iv2 = bcface%tab(k+1)
-                    IF(iv2 < iv1) THEN
-                        m = iv1
-                        iv1 = iv2
-                        iv2 = m
-                    END IF
+        ! Initializes face permutation array
+        ALLOCATE(perm(nfaces), stat=info)
+        IF(info /= 0) THEN
+            WRITE(*,100)
+            CALL abort_psblas
+        END IF
+        DO IF = 1, nfaces
+            perm(IF) = IF
+        END DO
 
-                    j1 = f2v%lookup(iv1)
-                    j2 = f2v%lookup(iv1+1) - 1
-                    v2f_2D: DO j = j1, j2
-                        if2 = f2v%tab(j)
-                        IF(faceslave(if2) /= 0 .OR. &
-                            & faceflag(if2) > 0) CYCLE
-                        l = v2f%lookup(if2)
-                        iv3 = v2f%tab(l)
-                        iv4 = v2f%tab(l+1)
-                        ! NOTE: ICEM don't respect on bc elements the right hand ordering!!
-                        ! => for successive benchmark forces iv3 < iv4
-                        IF(iv4 < iv3) THEN
-                            m = iv4
-                            iv4 = iv3
-                            iv3 = m
+        ! Locates repeated faces and sets their flags = -1
+        IF(ncd == 2) THEN
+            pile_2D:  DO iv = 1, nverts
+                i = f2v%lookup(iv) - 1 ! Offset
+                n = f2v%lookup(iv+1) - f2v%lookup(iv) ! # of elements
+                if1_2D: DO j = 1, n
+                    if1 = f2v%tab(i+j)
+                    IF(iflag(if1) == -1 .OR. islave(if1) /= 0) CYCLE
+                    i1 = v2f%lookup(if1) - 1
+                    iv1 = v2f%tab(i1+1) ! 1st iv of if1
+                    iv2 = v2f%tab(i1+2) ! 2nd iv of if1
+                    if2_2D: DO k = j + 1, n
+                        if2 = f2v%tab(i+k)
+                        i2 = v2f%lookup(if2)-1
+                        iv3 = v2f%tab(i2+1) ! 1st iv of if2
+                        iv4 = v2f%tab(i2+2) ! 2nd iv of if2
+                        !---
+                        IF(iv4 == iv1 .AND. iv3 == iv2) THEN
+                            iflag(if2) = -1
+                            islave(if1) = imaster(if2)
+                            imaster(if2) = 0
+                            perm(if2) = if1
+                            EXIT if2_2D
                         END IF
-                        IF(iv1 == iv3 .AND. iv2 == iv4 ) THEN
-                            faceflag(if2) = ib
-                            f2b%tab(i) = if2
-                            EXIT v2f_2D
-                        END IF
-                    END DO v2f_2D
-                END DO bcface_2D
-            END DO ib_2D
+                    END DO if2_2D
+                END DO if1_2D
+            END DO pile_2D
         ELSE IF(ncd == 3) THEN
-            ALLOCATE(work1(4),work2(4),stat=info)
+            ALLOCATE(buf(6),stat=info)
             IF(info /= 0) THEN
                 WRITE(*,100)
                 CALL abort_psblas
             END IF
-            ib_3D: DO ib = 1, nbc
-                i1 = f2b%lookup(ib)
-                i2 = f2b%lookup(ib+1) - 1
-                bcface_3D: DO i = i1, i2
-                    if1 = f2b%tab(i) - ncells ! Offset of cell-sections
-                    ! NOTE: ICEM don't respect on bc elements the right hand ordering!!
-                    ! Vertices sequences of if1 and if2 faces are copied respectively in
-                    ! arrrays work1 and work2 then ordered.
-                    j1 = bcface%lookup(if1)
-                    j2 = bcface%lookup(if1+1) - 1
-                    l = 0
-                    DO j = j1, j2
-                        l = l + 1
-                        work1(l) = bcface%tab(j)
-                    END DO
-                    IF(l == 3) work1(4) = 0
-                    CALL sort(work1(1:l))
-
-                    iv1 = work1(1)
-                    j1 = f2v%lookup(iv1)
-                    j2 = f2v%lookup(iv1+1) - 1
-                    ! NOTE: l=number of vertex of if1. DO NOT CHANGE during next inner loop!!
-
-                    v2f_3D: DO j = j1, j2
-                        if2 = f2v%tab(j)
-                        IF(faceslave(if2) /= 0   .OR.&
-                            & faceflag(if2) > 0 .OR.&
-                            & facenv(if2) /= l) CYCLE
-                        k1 = v2f%lookup(if2)
-                        k2 = v2f%lookup(if2+1) - 1
-                        m = 0
-                        DO k = k1, k2
-                            m = m + 1
-                            work2(m) = v2f%tab(k)
-                        END DO
-                        CALL sort(work2(1:m))
-                        IF(    work1(1) == work2(1) .AND. &
-                            & work1(2) == work2(2) .AND. &
-                            & work1(3) == work2(3)) THEN
-                            faceflag(if2) = ib
-                            f2b%tab(i) = if2
-                            EXIT v2f_3D
-                        END IF
-                    END DO v2f_3D
-                END DO bcface_3D
-            END DO ib_3D
-            DEALLOCATE(work1,work2)
+            ! ---
+            pile_3D:  DO iv = 1, nverts
+                i = f2v%lookup(iv) - 1! Offset
+                n = f2v%lookup(iv+1) - f2v%lookup(iv) ! # of elements
+                if1_3D: DO j = 1, n - 1
+                    if1 = f2v%tab(i+j)
+                    IF(iflag(if1) == -1 .OR. islave(if1) /= 0) CYCLE
+                    ! iflag(if1) = -1  --> repeated face
+                    ! islave(if1) /= 0 --> already examinated face
+                    i1 = v2f%lookup(if1) - 1
+                    iv1 = v2f%tab(i1+1)
+                    iv2 = v2f%tab(i1+2)
+                    iv3 = v2f%tab(i1+3)
+                    found = .FALSE.
+                    if2_3D: DO k = j + 1, n
+                        if2 = f2v%tab(i+k)
+                        i2 = v2f%lookup(if2)
+                        j2 = v2f%lookup(if2+1)-1
+                        l = fnv(if2)
+                        ! Copies if2 iv-sequence in buf
+                        buf(1) = v2f%tab(j2)
+                        buf(2:(l+1)) = v2f%tab(i2:j2)
+                        buf(l+2) = v2f%tab(i2)
+                        IF(l == 3) buf(6)=0
+                        !---
+                        ! Searches for iv2 in buf
+                        match: DO m = 2, (l+1)
+                            IF(buf(m) /= iv2) CYCLE
+                            IF(buf(m+1) == iv1 .AND. buf(m-1) == iv3) THEN
+                                iflag(if2) = -1
+                                islave(if1) = imaster(if2)
+                                imaster(if2) = 0
+                                perm(if2) = if1
+                                found = .TRUE.
+                            END IF
+                        END DO match
+                        IF(found) EXIT if2_3D
+                    END DO if2_3D
+                END DO if1_3D
+            END DO pile_3D
+            DEALLOCATE(buf)
         END IF
         CALL f2v%free_table()
-        CALL bcface%free_table()
-    ELSE
-        ! NBC = 0
-        nbc = 1
-        bcname(1) = 'bc1'; bcnf(1) = COUNT(faceslave == 0)
-        f2b%lookup(1) = k + 1
+
+        ! ###########################################################################
+        IF (debug) THEN
+            DO IF = 1, nfaces
+                WRITE(*,330) IF, iflag(IF), imaster(IF), islave(IF)
+            END DO
+            WRITE(*,*)
+330         FORMAT(' face: ',i4,' flag: ',i2,' master: ',i4,' slave: ',i4)
+        END IF
+        ! ###########################################################################
+
+        ! Completes definition of permutation array
+        ! new=perm(old)
+        ! old=pinv(new)
+        !
+        ! By first faces with iflag(if)=0 ...
+        j = 0
         DO IF = 1, nfaces
-            IF(faceslave(IF) == 0) THEN
-                k = k + 1
-                f2b%tab(k) = IF
+            IF(iflag(IF) == 0) THEN
+                j = j + 1
+                perm(IF) = j
             END IF
         END DO
-        f2b%lookup(2) = k + 1
-        WHERE (faceslave == 0)
-            faceflag = 1
-        END WHERE
-    END IF
-    DEALLOCATE(f2btab_cg)
-
-    ! Reordering of if-indexing following the flag sequence: 0,1,2,...,nbc
-    ! f2b%tab is used for building the inverse permutation array pinv
-    ! old = pinv(new)
-    ! new = perm(old)
-
-    k = SIZE(v2f%tab)
-    ALLOCATE(perm(nfaces),pinv(nfaces),aux(4,nfaces),stat=info)
-    IF(info /= 0) THEN
-        WRITE(*,100)
-        CALL abort_psblas
-    END IF
-    CALL dmy%alloc_table(nel=nfaces,ntab=k)
-
-    ! Builds pinv
-    k = 0
-    ! First fluid faces ...
-    DO IF = 1, nfaces
-        IF(faceflag(IF) == 0) THEN
-            k = k + 1
-            pinv(k) = IF
-        END IF
-    END DO
-    ! ... then bc faces.
-    pinv(k+1:nfaces) = f2b%tab
-
-    DO IF = 1, nfaces
-        aux(1,IF) = facenv(IF)
-        aux(2,IF) = faceflag(IF)
-        aux(3,IF) = facemaster(IF)
-        aux(4,IF) = faceslave(IF)
-    END DO
-
-    DO IF = 1, nfaces
-        j = pinv(IF)
-        perm(j) = IF ! Permutation array
-        facenv(IF)     = aux(1,j)
-        faceflag(IF)   = aux(2,j)
-        facemaster(IF) = aux(3,j)
-        faceslave(IF)  = aux(4,j)
-    END DO
-
-    ! Reordering of v2f%tab and v2f%lookup
-    k  = SIZE(v2f%tab)
-    dmy%lookup  = v2f%lookup(1:nfaces+1)
-    dmy%tab = v2f%tab(1:k)
-    i1 = 1; i2 = 0; v2f%tab(i1) = 1
-    DO IF = 1, nfaces
-        i2 = i1 + facenv(IF) - 1
-
-        j = pinv(IF)
-        j1 = dmy%lookup(j)
-        j2 = j1 + facenv(IF) - 1
-
-        v2f%tab(i1:i2) = dmy%tab(j1:j2)
-
-        i1 = i2 + 1
-        v2f%lookup(IF+1) = i1
-    END DO
-
-    ! Reordering of f2c%tab
-    k = SIZE(f2c%tab)
-    DO i = 1, k
-        j = f2c%tab(i)
-        f2c%tab(i) = perm(j)
-    END DO
-
-    ! Counts total number of bc faces
-    nbcfaces = COUNT(faceslave == 0)
-
-    ! Redifinition of f2b%tab
-    k = COUNT(faceflag == 0) ! Fluid faces
-    DO IF = 1, nbcfaces
-        f2b%tab(IF) = IF + k
-    END DO
-
-    ! ###########################################################################
-    IF (debug) THEN
-        WRITE(*,370) (f2b%tab(i), i = 1, f2b%lookup(1) - 1)
-        WRITE(*,*)
-
-        DO ib = 1, nbc
-            i1 = f2b%lookup(ib)
-            i2 = i1 + bcnf(ib) - 1
-            WRITE(*,380) ib, bcname(ib), f2b%tab(i1:i2)
+        ! ... then faces with iflag(if)=-1
+        DO IF = 1, nfaces
+            IF(iflag(IF) == -1) THEN
+                j = perm(IF)
+                perm(IF) = perm(j)
+            END IF
         END DO
-        WRITE(*,*)
+
+        ! ###########################################################################
+        IF(debug) THEN
+            n = COUNT(iflag == 0)
+            DO IF = 1, nfaces
+                i1 = v2f%lookup(IF)
+                k = fnv(IF)
+                WRITE(*,340) IF, iflag(IF), perm(IF), (v2f%tab(j), j = i1, i1+k-1)
+            END DO
+            WRITE(*,*)
+            DO IF = 1,nfaces
+                i1 = v2f%lookup(IF)
+                k = fnv(IF)
+            END DO
+340         FORMAT(' face: ',i5,' flag: ',i2,' perm: ',i5,' vertices',4i5)
+        END IF
+        ! ###########################################################################
+
+        ! Reordering of face based arrays
+
+        ! Updates NFACES and stores OLD NFACES in N
+        n = nfaces
+        nfaces = COUNT(iflag == 0)
+
+        ! Allocation of PINV and definitive face-related arrays
+        ALLOCATE(pinv(nfaces), facenv(nfaces), faceflag(nfaces),&
+            & facemaster(nfaces), faceslave(nfaces), stat=info)
+        IF(info /= 0) THEN
+            WRITE(*,100)
+            CALL abort_psblas
+        END IF
+
+        ! Builds inverse permutation array for the NEW first NFACES faces
+        DO IF = 1, n
+            IF (iflag(IF) == 0) THEN
+                j = perm(IF)
+                pinv(j) = IF
+            END IF
+        END DO
+
+        ! Reordering and definition of FACE face-object
+        DO IF = 1, nfaces
+            j = pinv(IF)
+
+            facenv(IF)     = fnv(j)
+            faceflag(IF)   = 0
+            facemaster(IF) = imaster(j)
+            faceslave(IF)  = islave(j)
+        END DO
+        DEALLOCATE(iflag,imaster,islave,fnv)
+
+        ! Reordering and reallocation of v2f
+        k = 0
+        DO IF = 1, nfaces
+            j = k
+            k = j + facenv(IF)
+        END DO
+        !
+        CALL dmy%alloc_table(nel=nfaces,ntab=k)
+        i1 = 1; i2 = 0; dmy%lookup(1) = 1
+        DO IF = 1, nfaces
+            j = pinv(IF)
+            i2 = i1 + facenv(IF) - 1
+            j1 = v2f%lookup(j)
+            j2 = j1 + facenv(IF) - 1
+            dmy%tab(i1:i2) = v2f%tab(j1:j2)
+            i1 = i2 + 1
+            dmy%lookup(IF+1) = i1
+        END DO
+        CALL v2f%free_table()
+
+        CALL v2f%alloc_table(nel=nfaces,ntab=k)
+        v2f%lookup = dmy%lookup(1:nfaces+1)
+        v2f%tab = dmy%tab(1:k)
+
+        ! Reordering of f2c%tab
+        DO ic = 1, ncells
+            i1 = f2c%lookup(ic)
+            i2 = f2c%lookup(ic+1) - 1
+            DO i = i1, i2
+                j = f2c%tab(i)
+                f2c%tab(i) = perm(j)
+            END DO
+        END DO
+
+        CALL dmy%free_table()
+        DEALLOCATE(perm,pinv)
+
+        ! ###########################################################################
+        IF(debug) THEN
+            DO IF = 1, nfaces
+                i1 = v2f%lookup(IF)
+                i2 = v2f%lookup(IF+1) - 1
+                WRITE(*,350) IF, facemaster(IF), faceslave(IF), v2f%tab(i1:i2)
+            END DO
+            WRITE(*,*)
+            DO ic = 1, ncells
+                i1 = f2c%lookup(ic)
+                i2 = f2c%lookup(ic+1) - 1
+                WRITE(*,360) ic, f2c%tab(i1:i2)
+            END DO
+            WRITE(*,*)
+350         FORMAT(' face: ',i5,' master: ',i5,' slave: ',i5,' vertices: ',4i5)
+360         FORMAT(' cell: ',i5, ' faces:',6(1x,i5))
+        END IF
+        ! ###########################################################################
+
+        ! --- Reads and assigns boundary conditions. Boundary flags are integer
+        ! in the range [1-NBC]. If NBC=0 from import, automatically NBC=1 and where
+        ! faceslave=0 a boundary face is asssumed.
+        ! --- Builds list of faces, grouping them by their flag value.
+        !
+        ! iflag(if)=0 --> fluid face
+        ! iflag(if)=i --> i-th boundary face
+        !
+
+        ! Counts boundary faces (faceslave = 0)
+        k = COUNT(faceslave == 0)
+
+        IF(nbc /= 0) THEN
+            CALL f2b%alloc_table(nel=nbc,ntab=k)
+            ALLOCATE(bcnf(nbc),bcname(nbc),stat=info)
+        ELSE
+            CALL f2b%alloc_table(nel=1,ntab=k)
+            ALLOCATE(bcnf(1),bcname(1),stat=info)
+        END IF
+        IF(info /= 0) THEN
+            WRITE(*,100)
+            CALL abort_psblas
+        END IF
+        ALLOCATE(f2btab_cg(k), stat=info)
+        IF(info /= 0) THEN
+            WRITE(*,100)
+            CALL abort_psblas
+        END IF
+        ALLOCATE(bcnf_cg(SIZE(bcnf)), stat=info)
+        IF(info /= 0) THEN
+            WRITE(*,100)
+            CALL abort_psblas
+        END IF
+
+        ! Reads bc section
+        IF(nbc /= 0) THEN
+            i1 = 1; i2 = 0; f2b%lookup(1) = i1
+            DO ib = 1, nbc
+                CALL cg_boco_info_f(index_file,index_base,index_zone,ib,&
+                    & bcname(ib),bocotype,ptset_type,bcnf_cg(ib),&
+                    & NormalIndex,NormalListFlag,NormalDataType,ndataset,ier)
+                IF(ier /= CG_OK) CALL cg_error_exit_f
+                ! NOTE: NORMAL* and NDATASET are unused
+                bcnf(ib) = bcnf_cg(ib)
+
+                i2 = i1 + bcnf(ib) - 1
+                CALL cg_boco_read_f(index_file,index_base,index_zone,ib,&
+                    & f2btab_cg(i1:i2),NormalList,ier)
+                IF(ier /= CG_OK) CALL cg_error_exit_f
+                f2b%tab(i1:i2) = f2btab_cg(i1:i2)
+                i1 = i2 + 1
+                f2b%lookup(ib+1) = i1
+            END DO
+            ! N = number of BC faces
+            n = f2b%lookup(nbc+1) - 1
+
+            ! Check on the consistency of bc faces
+            IF(n /= COUNT(faceslave == 0)) THEN
+                WRITE(*,*) 'ERROR! Inconsistent number of bc faces in CGNS file'
+                CALL abort_psblas
+            END IF
+
+            !
+            ! Counts records and elements of bc-sections; to use in the successive
+            ! allocation of bcface%lookup, bcface%tab.
+            ! NOTE: this is necessary because it can happen that the total amount of records in
+            ! presumed 'bc'-section is greater than the effective number of bc faces.
+            ! --> to be investigated more deeply in ICEM!
+            k1 = 0; k2 = 0
+            DO index_sect = isect_cell + 1, isect_bc
+                CALL cg_section_read_f(index_file,index_base,index_zone,index_sect,&
+                    & sectionname,itype,istart,iend,nbndry,iparent_flag,ier)
+                IF(ier /= CG_OK) CALL cg_error_exit_f
+                n = iend - istart + 1 ! Number of records, i.e. faces, inside the bc-section
+                k1 = k1 + n           ! Increases bcface%lookup elements number
+                SELECT CASE(itype)
+                CASE(3) ! bar
+                    l=2
+                CASE(5) ! tri
+                    l=3
+                CASE(7) ! quad
+                    l=4
+                CASE default
+                    WRITE(*,*) 'WARNING! Unsupported type of CGNS bc element: itype =', itype, 'IGNORING'
+                    CONTINUE
+                END SELECT
+                k2=k2+n*l ! Increases bcface%tab elements number
+            END DO
+
+            ! Allocates bcface%lookup, bcface%tab
+            CALL bcface%alloc_table(nel=k1,ntab=k2)
+            ALLOCATE(bcfacetab_cg(k2), stat=info)
+            IF(info /= 0) THEN
+                WRITE(*,100)
+                CALL abort_psblas
+            END IF
+
+            ! Reads sections containing boundary elements
+            bcface%lookup(1) = 1
+            DO index_sect = isect_cell + 1, isect_bc
+                CALL cg_section_read_f(index_file,index_base,index_zone,index_sect,&
+                    & sectionname,itype,istart,iend,nbndry,iparent_flag,ier)
+                IF(ier /= CG_OK) CALL cg_error_exit_f
+                SELECT CASE(itype)
+                CASE(3) ! bar
+                    l = 2
+                CASE(5) ! tri
+                    l = 3
+                CASE(7) ! quad
+                    l = 4
+                CASE default
+                    WRITE(*,*) 'WARNING! Unsupported type of CGNS bc element: itype =', itype, 'IGNORING'
+                    CONTINUE
+                END SELECT
+                i1 = istart - ncells
+                i2 = iend - ncells
+                DO i = i1, i2
+                    bcface%lookup(i+1) = bcface%lookup(i) + l
+                END DO
+                j1 = bcface%lookup(i1)
+                j2 = bcface%lookup(i2+1) - 1
+                CALL cg_elements_read_f(index_file,index_base,index_zone,index_sect,&
+                    & bcfacetab_cg(j1:j2),iparentdata,ier)
+                IF(ier /= CG_OK) CALL cg_error_exit_f
+                bcface%tab(j1:j2) = bcfacetab_cg(j1:j2)
+            END DO
+
+            DEALLOCATE(bcfacetab_cg)
+
+            ! Builds connection table f2v, dual of v2f
+            CALL get_dual_table(v2f,f2v)
+
+            ! Associates bc elements to corresponding faces
+            IF(ncd == 2) THEN
+                ib_2D: DO ib = 1, nbc
+                    i1 = f2b%lookup(ib)
+                    i2 = f2b%lookup(ib+1) - 1
+                    bcface_2D: DO i = i1, i2
+                        if1 = f2b%tab(i) - ncells ! Offset of cell-sections
+                        k = bcface%lookup(if1)
+                        ! NOTE: ICEM don't respect on bc elements the right hand ordering!!
+                        ! => for successive benchmark forces iv1 < iv2
+                        iv1 = bcface%tab(k)
+                        iv2 = bcface%tab(k+1)
+                        IF(iv2 < iv1) THEN
+                            m = iv1
+                            iv1 = iv2
+                            iv2 = m
+                        END IF
+
+                        j1 = f2v%lookup(iv1)
+                        j2 = f2v%lookup(iv1+1) - 1
+                        v2f_2D: DO j = j1, j2
+                            if2 = f2v%tab(j)
+                            IF(faceslave(if2) /= 0 .OR. &
+                                & faceflag(if2) > 0) CYCLE
+                            l = v2f%lookup(if2)
+                            iv3 = v2f%tab(l)
+                            iv4 = v2f%tab(l+1)
+                            ! NOTE: ICEM don't respect on bc elements the right hand ordering!!
+                            ! => for successive benchmark forces iv3 < iv4
+                            IF(iv4 < iv3) THEN
+                                m = iv4
+                                iv4 = iv3
+                                iv3 = m
+                            END IF
+                            IF(iv1 == iv3 .AND. iv2 == iv4 ) THEN
+                                faceflag(if2) = ib
+                                f2b%tab(i) = if2
+                                EXIT v2f_2D
+                            END IF
+                        END DO v2f_2D
+                    END DO bcface_2D
+                END DO ib_2D
+            ELSE IF(ncd == 3) THEN
+                ALLOCATE(work1(4),work2(4),stat=info)
+                IF(info /= 0) THEN
+                    WRITE(*,100)
+                    CALL abort_psblas
+                END IF
+                ib_3D: DO ib = 1, nbc
+                    i1 = f2b%lookup(ib)
+                    i2 = f2b%lookup(ib+1) - 1
+                    bcface_3D: DO i = i1, i2
+                        if1 = f2b%tab(i) - ncells ! Offset of cell-sections
+                        ! NOTE: ICEM don't respect on bc elements the right hand ordering!!
+                        ! Vertices sequences of if1 and if2 faces are copied respectively in
+                        ! arrrays work1 and work2 then ordered.
+                        j1 = bcface%lookup(if1)
+                        j2 = bcface%lookup(if1+1) - 1
+                        l = 0
+                        DO j = j1, j2
+                            l = l + 1
+                            work1(l) = bcface%tab(j)
+                        END DO
+                        IF(l == 3) work1(4) = 0
+                        CALL sort(work1(1:l))
+
+                        iv1 = work1(1)
+                        j1 = f2v%lookup(iv1)
+                        j2 = f2v%lookup(iv1+1) - 1
+                        ! NOTE: l=number of vertex of if1. DO NOT CHANGE during next inner loop!!
+
+                        v2f_3D: DO j = j1, j2
+                            if2 = f2v%tab(j)
+                            IF(faceslave(if2) /= 0   .OR.&
+                                & faceflag(if2) > 0 .OR.&
+                                & facenv(if2) /= l) CYCLE
+                            k1 = v2f%lookup(if2)
+                            k2 = v2f%lookup(if2+1) - 1
+                            m = 0
+                            DO k = k1, k2
+                                m = m + 1
+                                work2(m) = v2f%tab(k)
+                            END DO
+                            CALL sort(work2(1:m))
+                            IF(    work1(1) == work2(1) .AND. &
+                                & work1(2) == work2(2) .AND. &
+                                & work1(3) == work2(3)) THEN
+                                faceflag(if2) = ib
+                                f2b%tab(i) = if2
+                                EXIT v2f_3D
+                            END IF
+                        END DO v2f_3D
+                    END DO bcface_3D
+                END DO ib_3D
+                DEALLOCATE(work1,work2)
+            END IF
+            CALL f2v%free_table()
+            CALL bcface%free_table()
+        ELSE
+            ! NBC = 0
+            nbc = 1
+            bcname(1) = 'bc1'; bcnf(1) = COUNT(faceslave == 0)
+            f2b%lookup(1) = k + 1
+            DO IF = 1, nfaces
+                IF(faceslave(IF) == 0) THEN
+                    k = k + 1
+                    f2b%tab(k) = IF
+                END IF
+            END DO
+            f2b%lookup(2) = k + 1
+            WHERE (faceslave == 0)
+                faceflag = 1
+            END WHERE
+        END IF
+        DEALLOCATE(f2btab_cg)
+
+        ! Reordering of if-indexing following the flag sequence: 0,1,2,...,nbc
+        ! f2b%tab is used for building the inverse permutation array pinv
+        ! old = pinv(new)
+        ! new = perm(old)
+
+        k = SIZE(v2f%tab)
+        ALLOCATE(perm(nfaces),pinv(nfaces),aux(4,nfaces),stat=info)
+        IF(info /= 0) THEN
+            WRITE(*,100)
+            CALL abort_psblas
+        END IF
+        CALL dmy%alloc_table(nel=nfaces,ntab=k)
+
+        ! Builds pinv
+        k = 0
+        ! First fluid faces ...
+        DO IF = 1, nfaces
+            IF(faceflag(IF) == 0) THEN
+                k = k + 1
+                pinv(k) = IF
+            END IF
+        END DO
+        ! ... then bc faces.
+        pinv(k+1:nfaces) = f2b%tab
 
         DO IF = 1, nfaces
-            WRITE(*,390) IF, faceflag(IF), facemaster(IF), faceslave(IF)
-        END DO
-        WRITE(*,*)
-
-        DO i = 0, nbc
-            WRITE(*,400) i, COUNT(faceflag == i)
+            aux(1,IF) = facenv(IF)
+            aux(2,IF) = faceflag(IF)
+            aux(3,IF) = facemaster(IF)
+            aux(4,IF) = faceslave(IF)
         END DO
 
-        WRITE(*,*)
-370     FORMAT(' Fluid faces: ',5i8:/(14x,5i8))
-380     FORMAT(' Bcset: ',i2,' Name: ',a10,' List of faces: ', 5i8:/(43x,5i8:))
-390     FORMAT(' faces: ',i5,' Flag: ',i2,' Master: ',i5,' Slave: ',i5)
-400     FORMAT(' Total amount of faces with flag',i3,':',i8)
-    END IF
-    ! ###########################################################################
-
-    ! f2b is no longer useful. It can be deallocated
-    CALL f2b%free_table()
-    CALL dmy%free_table()
-    DEALLOCATE(bcname,bcnf)
-    DEALLOCATE(bcnf_cg)
-    DEALLOCATE(perm,pinv,aux)
-
-    ! Defines ON_BOUNDARY array
-    ALLOCATE(on_boundary(nverts),stat=info)
-    IF(info /= 0) THEN
-        WRITE(*,100)
-        CALL abort_psblas
-    END IF
-    on_boundary = .FALSE.
-
-    k = COUNT(faceflag == 0) + 1 ! Offset
-
-    ! Loop on boundary faces
-    DO IF = k, nfaces
-        i1 = v2f%lookup(IF)
-        i2 = v2f%lookup(IF+1) - 1
-        DO i = i1, i2
-            iv = v2f%tab(i)
-            on_boundary(iv) = .TRUE.
+        DO IF = 1, nfaces
+            j = pinv(IF)
+            perm(j) = IF ! Permutation array
+            facenv(IF)     = aux(1,j)
+            faceflag(IF)   = aux(2,j)
+            facemaster(IF) = aux(3,j)
+            faceslave(IF)  = aux(4,j)
         END DO
-    END DO
 
-    ! Copies vertex-related data in to the object VERTS of VERTEX class
-    CALL alloc_vertex(verts,nverts)
-    verts = vertex_(xv,yv,zv,on_boundary)
-    DEALLOCATE(xv,yv,zv,on_boundary)
+        ! Reordering of v2f%tab and v2f%lookup
+        k  = SIZE(v2f%tab)
+        dmy%lookup  = v2f%lookup(1:nfaces+1)
+        dmy%tab = v2f%tab(1:k)
+        i1 = 1; i2 = 0; v2f%tab(i1) = 1
+        DO IF = 1, nfaces
+            i2 = i1 + facenv(IF) - 1
 
-    ! Copies face-related data in to the object FACES of FACE class
-    CALL alloc_face(faces,nfaces)
-    faces = face_(facenv,facemaster,faceslave,faceflag)
-    DEALLOCATE(facenv,facemaster,faceslave,faceflag)
+            j = pinv(IF)
+            j1 = dmy%lookup(j)
+            j2 = j1 + facenv(IF) - 1
 
-    ! Copies cell-related data in to the object CELLS of CELL class
-    CALL alloc_cell(cells,ncells)
-    cells = cell_(cellnv,cellnf,cellgroup,cellgeo)
-    DEALLOCATE(cellnv,cellnf,cellgroup,cellgeo)
+            v2f%tab(i1:i2) = dmy%tab(j1:j2)
 
-    ! Copies connectivities  V2F, V2C, F2C to dummy arguments V2F_, V2C_, F2C_
-    ! (objects of CONNECTIVITY class)
-    CALL alloc_conn(v2f_,nel=nfaces,nconn=SIZE(v2f%tab))
-    CALL alloc_conn(v2c_,nel=ncells,nconn=SIZE(v2c%tab))
-    CALL alloc_conn(f2c_,nel=ncells,nconn=SIZE(f2c%tab))
-    CALL alloc_conn(c2g_,nel=ngroups,nconn=SIZE(c2g%tab))
+            i1 = i2 + 1
+            v2f%lookup(IF+1) = i1
+        END DO
 
-    DO IF = 1, nfaces
-        i1 = v2f%lookup(IF)
-        i2 = v2f%lookup(IF+1) - 1
-        CALL v2f_%set_ith_conn(IF,v2f%tab(i1:i2))
-    END DO
+        ! Reordering of f2c%tab
+        k = SIZE(f2c%tab)
+        DO i = 1, k
+            j = f2c%tab(i)
+            f2c%tab(i) = perm(j)
+        END DO
 
-    DO ic = 1, ncells
-        i1 = v2c%lookup(ic)
-        i2 = v2c%lookup(ic+1) - 1
-        CALL v2c_%set_ith_conn(ic,v2c%tab(i1:i2))
-    END DO
+        ! Counts total number of bc faces
+        nbcfaces = COUNT(faceslave == 0)
 
-    DO ic = 1, ncells
-        i1 = f2c%lookup(ic)
-        i2 = f2c%lookup(ic+1) - 1
-        CALL f2c_%set_ith_conn(ic,f2c%tab(i1:i2))
-    END DO
+        ! Redifinition of f2b%tab
+        k = COUNT(faceflag == 0) ! Fluid faces
+        DO IF = 1, nbcfaces
+            f2b%tab(IF) = IF + k
+        END DO
 
-    DO ig = 1, ngroups
-        i1 = c2g%lookup(ig)
-        i2 = c2g%lookup(ig+1) - 1
-        CALL c2g_%set_ith_conn(ig,c2g%tab(i1:i2))
-    END DO
+        ! ###########################################################################
+        IF (debug) THEN
+            WRITE(*,370) (f2b%tab(i), i = 1, f2b%lookup(1) - 1)
+            WRITE(*,*)
 
-    ! Deallocates local copies of connectivity data
-    CALL v2f%free_table()
-    CALL v2c%free_table()
-    CALL f2c%free_table()
-    CALL c2g%free_table()
+            DO ib = 1, nbc
+                i1 = f2b%lookup(ib)
+                i2 = i1 + bcnf(ib) - 1
+                WRITE(*,380) ib, bcname(ib), f2b%tab(i1:i2)
+            END DO
+            WRITE(*,*)
 
-    ! Currently group data GROUPNC, GROUPMAT, GROUPNAME are not exported
-    ! to the calling program => deallocation
-    DEALLOCATE(groupnc,groupmat,groupname)
+            DO IF = 1, nfaces
+                WRITE(*,390) IF, faceflag(IF), facemaster(IF), faceslave(IF)
+            END DO
+            WRITE(*,*)
 
-    CALL cg_close_f(index_file,ier)
-    IF(ier /= CG_OK) CALL cg_error_exit_f
+            DO i = 0, nbc
+                WRITE(*,400) i, COUNT(faceflag == i)
+            END DO
 
-    WRITE(*,'()')
+            WRITE(*,*)
+370         FORMAT(' Fluid faces: ',5i8:/(14x,5i8))
+380         FORMAT(' Bcset: ',i2,' Name: ',a10,' List of faces: ', 5i8:/(43x,5i8:))
+390         FORMAT(' faces: ',i5,' Flag: ',i2,' Master: ',i5,' Slave: ',i5)
+400         FORMAT(' Total amount of faces with flag',i3,':',i8)
+        END IF
+        ! ###########################################################################
 
-100 FORMAT(' ERROR! Memory allocation failure in RD_CGNS_MESH')
+        ! f2b is no longer useful. It can be deallocated
+        CALL f2b%free_table()
+        CALL dmy%free_table()
+        DEALLOCATE(bcname,bcnf)
+        DEALLOCATE(bcnf_cg)
+        DEALLOCATE(perm,pinv,aux)
+
+        ! Defines ON_BOUNDARY array
+        ALLOCATE(on_boundary(nverts),stat=info)
+        IF(info /= 0) THEN
+            WRITE(*,100)
+            CALL abort_psblas
+        END IF
+        on_boundary = .FALSE.
+
+        k = COUNT(faceflag == 0) + 1 ! Offset
+
+        ! Loop on boundary faces
+        DO IF = k, nfaces
+            i1 = v2f%lookup(IF)
+            i2 = v2f%lookup(IF+1) - 1
+            DO i = i1, i2
+                iv = v2f%tab(i)
+                on_boundary(iv) = .TRUE.
+            END DO
+        END DO
+
+        ! Copies vertex-related data in to the object VERTS of VERTEX class
+        CALL alloc_vertex(verts,nverts)
+        verts = vertex_(xv,yv,zv,on_boundary)
+        DEALLOCATE(xv,yv,zv,on_boundary)
+
+        ! Copies face-related data in to the object FACES of FACE class
+        CALL alloc_face(faces,nfaces)
+        faces = face_(facenv,facemaster,faceslave,faceflag)
+        DEALLOCATE(facenv,facemaster,faceslave,faceflag)
+
+        ! Copies cell-related data in to the object CELLS of CELL class
+        CALL alloc_cell(cells,ncells)
+        cells = cell_(cellnv,cellnf,cellgroup,cellgeo)
+        DEALLOCATE(cellnv,cellnf,cellgroup,cellgeo)
+
+        ! Copies connectivities  V2F, V2C, F2C to dummy arguments V2F_, V2C_, F2C_
+        ! (objects of CONNECTIVITY class)
+        CALL alloc_conn(v2f_,nel=nfaces,nconn=SIZE(v2f%tab))
+        CALL alloc_conn(v2c_,nel=ncells,nconn=SIZE(v2c%tab))
+        CALL alloc_conn(f2c_,nel=ncells,nconn=SIZE(f2c%tab))
+        CALL alloc_conn(c2g_,nel=ngroups,nconn=SIZE(c2g%tab))
+
+        DO IF = 1, nfaces
+            i1 = v2f%lookup(IF)
+            i2 = v2f%lookup(IF+1) - 1
+            CALL v2f_%set_ith_conn(IF,v2f%tab(i1:i2))
+        END DO
+
+        DO ic = 1, ncells
+            i1 = v2c%lookup(ic)
+            i2 = v2c%lookup(ic+1) - 1
+            CALL v2c_%set_ith_conn(ic,v2c%tab(i1:i2))
+        END DO
+
+        DO ic = 1, ncells
+            i1 = f2c%lookup(ic)
+            i2 = f2c%lookup(ic+1) - 1
+            CALL f2c_%set_ith_conn(ic,f2c%tab(i1:i2))
+        END DO
+
+        DO ig = 1, ngroups
+            i1 = c2g%lookup(ig)
+            i2 = c2g%lookup(ig+1) - 1
+            CALL c2g_%set_ith_conn(ig,c2g%tab(i1:i2))
+        END DO
+
+        ! Deallocates local copies of connectivity data
+        CALL v2f%free_table()
+        CALL v2c%free_table()
+        CALL f2c%free_table()
+        CALL c2g%free_table()
+
+        ! Currently group data GROUPNC, GROUPMAT, GROUPNAME are not exported
+        ! to the calling program => deallocation
+        DEALLOCATE(groupnc,groupmat,groupname)
+
+        CALL cg_close_f(index_file,ier)
+        IF(ier /= CG_OK) CALL cg_error_exit_f
+
+        WRITE(*,'()')
+
+100     FORMAT(' ERROR! Memory allocation failure in RD_CGNS_MESH')
 
         END PROCEDURE rd_cgns_mesh
 

--- a/src/FV/src/mesh_basics/class_cell_procedures.F90
+++ b/src/FV/src/mesh_basics/class_cell_procedures.F90
@@ -461,7 +461,7 @@ CONTAINS
             CASE(ihex_)
                 khex = khex + 1
                 ictype(khex) = ic
-            CASE default
+            CASE DEFAULT
                 WRITE(*,200)
                 CALL abort_psblas
             END SELECT

--- a/src/FV/src/mesh_basics/class_surface_procedures.f90
+++ b/src/FV/src/mesh_basics/class_surface_procedures.f90
@@ -235,7 +235,7 @@ CONTAINS
         CASE (icylinder_)
             get_surface_normal = this_surface%my_cylinder%get_cylinder_normal(this_point)
 
-        CASE default
+        CASE DEFAULT
             WRITE(6,100)
             CALL abort_psblas
 
@@ -261,7 +261,7 @@ CONTAINS
         CASE (icylinder_)
             get_surface_r2 = this_surface%my_cylinder%get_cylinder_r2()
 
-        CASE default
+        CASE DEFAULT
             WRITE(6,100)
             CALL abort_psblas
 
@@ -287,7 +287,7 @@ CONTAINS
         CASE (icylinder_)
             CALL this_surface%my_cylinder%translate_cylinder(offset)
 
-        CASE default
+        CASE DEFAULT
             ! do nothing...there are no data describing an irregular surface
         END SELECT
 
@@ -308,7 +308,7 @@ CONTAINS
         CASE (icylinder_)
             get_closest_point = this_surface%my_cylinder%get_pt_cylinder(point)
 
-        CASE default
+        CASE DEFAULT
             WRITE(6,100)
             CALL abort_psblas
 

--- a/src/FV/src/mesh_basics/geom_cell.f90
+++ b/src/FV/src/mesh_basics/geom_cell.f90
@@ -248,7 +248,7 @@ SUBMODULE(tools_mesh_basics) geom_cell_implementation
 
                         r = 1.d0 / vol(ic)
                         cell_cntr(ic) = r * cell_cntr(ic)
-                    CASE default
+                    CASE DEFAULT
                         ! Generic Polyhedron
 
                         ! Evaluation of tetrahedra "4th" point P, set equal to the

--- a/src/FV/src/operators/scalar_pde_div.f90
+++ b/src/FV/src/operators/scalar_pde_div.f90
@@ -339,7 +339,7 @@ SUBMODULE (op_div) scalar_pde_div_implementation
                     sp_bc(i,ib) = fact
                 ENDIF
             END DO
-        CASE default
+        CASE DEFAULT
             WRITE(*,402)
             CALL abort_psblas
         END SELECT

--- a/src/FV/src/operators/scalar_pde_laplacian.f90
+++ b/src/FV/src/operators/scalar_pde_laplacian.f90
@@ -423,7 +423,7 @@ SUBMODULE (op_laplacian) scalar_pde_laplacian_implementation
                     sc_bc(i,ib) = fact * bc_c(i)
                     sp_bc(i,ib) = fact * bc_a(i)
                 END DO
-            CASE default
+            CASE DEFAULT
                 WRITE(*,500)
                 CALL abort_psblas
             END SELECT

--- a/src/FV/src/operators/tools_operators_procedures.f90
+++ b/src/FV/src/operators/tools_operators_procedures.f90
@@ -58,7 +58,7 @@ CONTAINS
             dsign = 1.d0
         CASE('-')
             dsign = -1.d0
-        CASE default
+        CASE DEFAULT
             WRITE(*,100)
             CALL abort_psblas
         END SELECT

--- a/src/FV/src/operators/vector_pde_div.f90
+++ b/src/FV/src/operators/vector_pde_div.f90
@@ -361,7 +361,7 @@ SUBMODULE (op_div) vector_pde_div_implementation
                     sp_bc(i,ib) = fact
                 ENDIF
             END DO
-        CASE default
+        CASE DEFAULT
             WRITE(*,402)
             CALL abort_psblas
         END SELECT

--- a/src/FV/src/operators/vector_pde_laplacian.f90
+++ b/src/FV/src/operators/vector_pde_laplacian.f90
@@ -440,7 +440,7 @@ SUBMODULE (op_laplacian) vector_pde_laplacian_implementation
                     sc_bc(i,ib) = fact * bc_c(i)
                 END DO
 
-            CASE default
+            CASE DEFAULT
                 WRITE(*,500) TRIM(op_name)
                 CALL abort_psblas
             END SELECT

--- a/src/FV/src/output/vtkmofo_implementation.f90
+++ b/src/FV/src/output/vtkmofo_implementation.f90
@@ -324,7 +324,7 @@ CONTAINS
             CASE(vtk_)
                 ! call wr_vtk_field(field,x_glob,msh%ncd,path)
                 ! Only need value for x_glob
-            CASE default
+            CASE DEFAULT
                 WRITE(*,300)
                 CALL abort_psblas
             END SELECT

--- a/src/FV/src/output/write_mesh.f90
+++ b/src/FV/src/output/write_mesh.f90
@@ -124,7 +124,7 @@ SUBMODULE (tools_output) write_mesh_implementation
                 SELECT CASE(out%fmt_())
                 CASE(vtk_)
                     !        call wr_vtk_mesh(msh%ncd,verts,cells,v2c,iproc,path)
-                CASE default
+                CASE DEFAULT
                     WRITE(*,200)
                 END SELECT
             END IF


### PR DESCRIPTION
* Removes some pre-existing `cmake` data that is no longer needed
* Fixes naming conventions in `cmake`
* Fixes mismatched upper / lower case naming
* Fixes indention for `rd_cgns_mesh.F90`