### PR TITLE
Keep gh-pages history to help revert mistakes

### DIFF
--- a/.github/workflows/FORD.yml
+++ b/.github/workflows/FORD.yml
@@ -122,8 +122,8 @@ jobs:
           PUBLISH_BRANCH: gh-pages
           PUBLISH_DIR: ./API-doc
         with:
-          emptyCommits: false
-          forceOrphan: true
+          emptyCommits: true
+          forceOrphan: false
           commitMessage: ${{ github.event.head_commit.message }}
           username: ${{ github.actor }}
         if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'


### PR DESCRIPTION
This will increase the repo size, but will be worth the expense.